### PR TITLE
Add UTF-8 to UCS-2 encoding and Simple File System Protocol support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,5 @@ pub use self::data_types::{Guid, Handle};
 pub mod table;
 
 pub mod proto;
+
+pub mod ucs2;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -20,3 +20,4 @@ pub trait Protocol {
 mod macros;
 
 pub mod console;
+pub mod sfs;

--- a/src/proto/sfs/mod.rs
+++ b/src/proto/sfs/mod.rs
@@ -1,0 +1,89 @@
+use {Status,Result,ucs2};
+use core::mem;
+
+pub const FILE_MODE_READ    : u64 = 0x0000000000000001;
+pub const FILE_MODE_WRITE   : u64 = 0x0000000000000002;
+pub const FILE_MODE_CREATE  : u64 = 0x8000000000000000;
+
+pub const FILE_READ_ONLY    : u64 = 0x0000000000000001;
+pub const FILE_HIDDEN       : u64 = 0x0000000000000002;
+pub const FILE_SYSTEM       : u64 = 0x0000000000000004;
+pub const FILE_RESERVED     : u64 = 0x0000000000000008;
+pub const FILE_DIRECTORY    : u64 = 0x0000000000000010;
+pub const FILE_ARCHIVE      : u64 = 0x0000000000000020;
+pub const FILE_VALID_ATTR   : u64 = 0x0000000000000037;
+
+#[repr(C)]
+pub struct File {
+    revision: u64,
+    open: extern "C" fn(this: &mut File, new_handle: &mut usize, filename: *const u16, open_mode: u64, attributes: u64) -> Status,
+    close: extern "C" fn(this: &mut File) -> Status,
+    delete: extern "C" fn(this: &mut File) -> Status,
+    read: extern "C" fn(this: &mut File, buffer_size: &mut usize, buffer: *mut u8) -> Status,
+    write: extern "C" fn(this: &mut File, buffer_size: &mut usize, buffer: *const u8) -> Status,
+    get_position: extern "C" fn(this: &mut File, position: &mut u64) -> Status,
+    set_position: extern "C" fn(this: &mut File, position: u64) -> Status,
+    get_info: usize,
+    set_info: usize,
+    flush: extern "C" fn(this: &mut File) -> Status,
+}
+
+#[repr(C)]
+pub struct SimpleFileSystem {
+    revision: u64,
+    open_volume: extern "C" fn(this: &mut SimpleFileSystem, root: &mut usize) -> Status, 
+}
+
+impl File {
+    pub fn open(&mut self, filename: &str, open_mode: u64, attributes: u64) -> Result<*mut File> {
+        const BUF_SIZE : usize = 128;
+        if filename.len() > BUF_SIZE {
+            Err(Status::InvalidParameter)
+        }
+        else {
+            let mut buf = [0u16; BUF_SIZE+1];
+            let mut ptr = 0usize;
+            match ucs2::encode_ucs2(filename, &mut buf) {
+                Ok(_) => { (self.open)(self, &mut ptr, buf.as_ptr(), open_mode, attributes).into_with(|| ptr as *mut File) },
+                Err(err) => { Err(err) },
+            }
+        }
+    }
+    pub fn close(&mut self) -> Result<()> {
+        (self.close)(self).into()
+    }
+    pub fn delete(&mut self) -> Result<()> {
+        (self.delete)(self).into()
+    }
+    pub fn read(&mut self, buffer: &mut[u8]) -> Result<usize> {
+        let mut buffer_size = buffer.len();
+        (self.read)(self, &mut buffer_size, buffer.as_mut_ptr()).into_with(|| buffer_size)
+    }
+    pub fn write(&mut self, buffer: &[u8]) -> Result<usize> {
+        let mut buffer_size = buffer.len();
+        (self.write)(self, &mut buffer_size, buffer.as_ptr()).into_with(|| buffer_size)
+    }
+    pub fn get_position(&mut self) -> Result<u64> {
+        let mut pos = 0u64;
+        (self.get_position)(self, &mut pos).into_with(|| pos)
+    }
+    pub fn set_position(&mut self, position: u64) -> Result<()> {
+        (self.set_position)(self, position).into()
+    }
+    pub fn flush(&mut self) -> Result<()> {
+        (self.flush)(self).into()
+    }
+}
+
+impl SimpleFileSystem {
+    pub fn open_volume(&mut self) -> Result<*mut File> {
+        let mut ptr = 0usize;
+        (self.open_volume)(self, &mut ptr).into_with(|| ptr as *mut File)
+    }
+}
+
+impl_proto! {
+    protocol SimpleFileSystem {
+        GUID = 0x0964e5b22,0x6459,0x11d2,[0x8e,0x39,0x00,0xa0,0xc9,0x69,0x72,0x3b];
+    }
+}

--- a/src/ucs2/mod.rs
+++ b/src/ucs2/mod.rs
@@ -1,0 +1,95 @@
+use {Status, Result};
+
+/// Encode UTF-8 string to UCS-2
+pub fn ucs2_encoder<F>(input: &str, mut output: F) -> Result<()>
+        where F: FnMut(u16) -> Result<()> {   
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        let mut ch = 0u16;
+
+        if bytes[i] & 0b1000_0000 == 0b0000_0000 {
+            ch = bytes[i] as u16;
+            i += 1;
+        }
+        else if bytes[i] & 0b1110_0000 == 0b1100_0000 {
+            // 2 byte codepoint
+            if i + 1 == len {
+                // Buffer underflow
+                return Err(Status::BadBufferSize);
+            }
+            if bytes[i+1] & 0b1100_0000 != 0b1000_0000 {
+                // Invalid data
+                return Err(Status::CompromisedData);
+            }
+            let a = (bytes[i] & 0b0001_1111) as u16;
+            let b = (bytes[i+1] & 0b0011_1111) as u16;
+            ch = a << 6 | b;
+            i += 2;
+        }
+        else if bytes[i] & 0b1111_0000 == 0b1110_0000 {
+            // 3 byte codepoint
+            if i + 2 >= len {
+                // Buffer underflow
+                return Err(Status::BadBufferSize);
+            }
+            if bytes[i+1] & 0b1100_0000 != 0b1000_0000 ||
+                bytes[i+2] & 0b1100_0000 != 0b1000_0000 {
+                // Invalid data
+                return Err(Status::CompromisedData);
+            }
+            let a = (bytes[i] & 0b0000_1111) as u16;
+            let b = (bytes[i+1] & 0b0011_1111) as u16;
+            let c = (bytes[i+2] & 0b0011_1111) as u16;
+            ch = a << 12 | b << 6 | c;
+            i += 3;
+        }
+        else if bytes[i] & 0b1111_0000 == 0b1111_0000 {
+            return Err(Status::Unsupported); // UTF-16
+        }
+        else {
+            return Err(Status::CompromisedData);
+        }
+        match output(ch) {
+            Ok(()) => {},
+            Err(err) => { return Err(err); },
+        }
+    }
+    Ok(())
+}
+
+pub fn encode_ucs2(input: &str, buffer: &mut [u16]) -> Result<usize> {
+    let mut result = Ok(());
+    let buffer_size = buffer.len();
+    let mut i = 0;
+    {
+    let add_ch = |ch| {
+        if i >= buffer_size {
+            Err(Status::BufferTooSmall)
+        }
+        else {
+            buffer[i] = ch;
+            i += 1;
+            if ch == '\n' as u16 {
+                if i == buffer_size {
+                    Err(Status::BufferTooSmall)
+                }
+                else {
+                    buffer[i] = '\r' as u16;
+                    i += 1;
+                    Ok(())
+                }
+            }
+            else {
+                Ok(())
+            }
+        }
+    };
+    result = ucs2_encoder(input, add_ch);
+    }
+    match result {
+        Ok(()) => { Ok(i) },
+        Err(err) => { Err(err) },
+    }
+}

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#![feature(slice_patterns)]
 #![feature(alloc)]
 #![feature(asm)]
 
@@ -16,6 +17,7 @@ extern crate alloc;
 mod debug;
 mod boot;
 mod proto;
+mod ucs2;
 
 use uefi::{Handle, Status};
 use uefi::table;
@@ -60,6 +62,11 @@ pub extern "C" fn uefi_start(handle: Handle, st: &'static table::SystemTable) ->
     match proto::protocol_test(bt) {
         Ok(_) => info!("Protocol test passed."),
         Err(status) => error!("Protocol test failed with status {:?}", status),
+    }
+
+    match ucs2::ucs2_encoding_test() {
+        Ok(_) => info!("UCS-2 encoding test passed"),
+        Err(status) => error!("UCS-2 encoding test failed with status {:?}", status),
     }
 
     bt.stall(4_000_000);

--- a/tests/src/ucs2.rs
+++ b/tests/src/ucs2.rs
@@ -1,0 +1,26 @@
+use uefi::{Status, Result};
+use uefi::ucs2::encode_ucs2;
+use alloc::Vec;
+
+pub fn ucs2_encoding_test() -> Result<()> {
+    let utf8_string = "őэ╋";
+    let mut ucs2_buffer : Vec<u16> = Vec::with_capacity(5);
+    unsafe {
+        ucs2_buffer.set_len(5);
+    }
+    match encode_ucs2(utf8_string, &mut ucs2_buffer) {
+        Ok(3) => {
+            unsafe { ucs2_buffer.set_len(3); }
+            match &ucs2_buffer[..] {
+                &[0x0151, 0x044D, 0x254B] => {
+                    Ok(())
+                }
+                _ => {
+                    Err(Status::CrcError)
+                }
+            }
+        }
+        Ok(_) => { Err(Status::CrcError) },
+        Err(err) => { Err(err) },
+    }
+}

--- a/uefi-logger/src/writer.rs
+++ b/uefi-logger/src/writer.rs
@@ -1,4 +1,5 @@
 use super::Output;
+use uefi::{ucs2,Status,Result};
 use core::{fmt, str};
 
 /// Struct which is used to implement the `fmt::Write` trait on a UEFI output protocol.
@@ -37,27 +38,33 @@ impl fmt::Write for OutputWriter {
             let mut add_char = |ch| {
                 // UEFI only supports UCS-2 characters, not UTF-16,
                 // so there are no multibyte characters.
-                let ch = ch as u16;
-
                 buf[i] = ch;
-
                 i += 1;
 
                 if i == BUF_SIZE {
-                    flush_buffer(&mut buf, &mut i)
+                    match flush_buffer(&mut buf, &mut i) {
+                        Ok(()) => { Ok(()) },
+                        Err(_) => { Err(Status::ProtocolError) },
+                    }
                 } else {
                     Ok(())
                 }
             };
-
-            for ch in s.chars() {
-                if ch == '\n' {
-                    // Prepend an '\r'.
-                    add_char('\r')?;
+            let mut add_ch = |ch| {
+                match add_char(ch) {
+                    Ok(()) => {
+                        if ch == '\n' as u16 {
+                            add_char('\r' as u16)
+                        }
+                        else {
+                            Ok(())
+                        }
+                    },
+                    Err(err) => { Err(err) }
                 }
+            };
 
-                add_char(ch)?;
-            }
+            ucs2::ucs2_encoder(s, add_ch);
         }
 
         // Flush whatever is left in the buffer.


### PR DESCRIPTION
Simple UTF-8 -> UCS-2 routine. Supports all multibyte UTF-8 sequences that are UCS-2 compatable.

Added most of the Simple File System Protocol, besides GetInfo and SetInfo on EFI_FILE_PROTOCOL. Still new to Rust, so not quite sure how to to provide those idiomatically