### PR TITLE
Implement `get_memory_map`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(const_fn)]
 #![feature(conservative_impl_trait)]
+#![feature(align_offset)]
 
 #![no_std]
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -308,6 +308,19 @@ pub struct MemoryDescriptor {
     pub att: MemoryAttribute,
 }
 
+impl Default for MemoryDescriptor {
+    fn default() -> MemoryDescriptor {
+        MemoryDescriptor {
+            ty: MemoryType::Reserved,
+            padding: 0,
+            phys_start: 0,
+            virt_start: 0,
+            page_count: 0,
+            att: MemoryAttribute::empty()
+        }
+    }
+}
+
 bitflags! {
     /// Flags describing the capabilities of a memory range.
     pub struct MemoryAttribute: u64 {

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -256,6 +256,7 @@ pub enum MemoryType {
 }
 
 /// A structure describing a region of memory.
+#[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -260,6 +260,8 @@ pub enum MemoryType {
 pub struct MemoryDescriptor {
     /// Type of memory occupying this range.
     pub ty: MemoryType,
+    /// Skip 4 bytes as UEFI declares items in structs should be naturally aligned
+    padding: u32,
     /// Starting physical address.
     pub phys_start: u64,
     /// Starting virtual address.

--- a/tests/src/boot.rs
+++ b/tests/src/boot.rs
@@ -10,5 +10,10 @@ pub fn boot_services_test(bt: &boot::BootServices) -> Result<()> {
 
     bt.free_pages(pgs, 1)?;
 
+    let mut mem_desc: [boot::MemoryDescriptor; 32] = [boot::MemoryDescriptor::default(); 32];
+    let mut buffer: [u8; 4096] = [0; 4096];
+    let (num_desc, _) = bt.get_memory_map(&mut mem_desc,&mut buffer)?;
+    info!("Found information for {} memory descriptors", num_desc);
+
     Ok(())
 }


### PR DESCRIPTION
Hi @GabrielMajeri 
This is a slightly awkward implementation of `get_memory_map` that I wrote for a project I'm doing and this PR is mostly to see if you have any interest in such an implementation or if I should keep this as a helper in my own library. Also if you have any better suggestions on how to implement this I would love to know.