### PR TITLE
Mark EFI status codes as must_use and check them

### DIFF
--- a/src/error/status.rs
+++ b/src/error/status.rs
@@ -11,6 +11,7 @@ const HIGHEST_BIT_SET: usize = !((!0_usize) >> 1);
 /// to indicate whether an operation completed successfully.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(usize)]
+#[must_use]
 pub enum Status {
     /// The operation completed successfully.
     Success,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -101,7 +101,8 @@ impl BootServices {
         let mut entry_size = 0;
         let mut entry_version = 0;
 
-        (self.memory_map)(&mut map_size, 0, &mut map_key, &mut entry_size, &mut entry_version);
+        let status = (self.memory_map)(&mut map_size, 0, &mut map_key, &mut entry_size, &mut entry_version);
+        assert_eq!(status, Status::BufferTooSmall);
 
         map_size * entry_size
     }
@@ -210,8 +211,7 @@ impl BootServices {
     ///
     /// The time is in microseconds.
     pub fn stall(&self, time: usize) {
-        // The spec says this cannot fail.
-        (self.stall)(time);
+        assert_eq!((self.stall)(time), Status::Success);
     }
 
     /// Copies memory from source to destination. The buffers can overlap.


### PR DESCRIPTION
Since forgetting to check status codes is a common mistake in APIs that use them, I think that marking the UEFI status codes as must_use is a good idea.

I added assertions in the two places where they were not checked (reasonably, as there is only one valid reply in the current spec), which should act as a protection against buggy firmwares or future revisions of the spec adding new status codes.