### PR TITLE
Add set_watchdog_timer implementation and test

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -50,7 +50,7 @@ pub struct BootServices {
     // Misc services
     get_next_monotonic_count: usize,
     stall: extern "C" fn(usize) -> Status,
-    set_watchdog_timer: usize,
+    set_watchdog_timer: extern "C" fn(timeout: usize, watchdog_code: u64, data_size: usize, watchdog_data: *mut u16) -> Status,
 
     // Driver support services
     connect_controller: usize,
@@ -234,6 +234,11 @@ impl BootServices {
     /// The time is in microseconds.
     pub fn stall(&self, time: usize) {
         assert_eq!((self.stall)(time), Status::Success);
+    }
+
+    /// Set the watchdog timer.
+    pub fn set_watchdog_timer(&self, timeout: usize, watchdog_code: u64, data_size: usize, watchdog_data: *mut u16) {
+        assert_eq!((self.set_watchdog_timer)(timeout, watchdog_code, data_size, watchdog_data), Status::Success);
     }
 
     /// Copies memory from source to destination. The buffers can overlap.

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,0 +1,10 @@
+use uefi::table::boot::BootServices;
+use core::ptr;
+
+pub fn test(bt: &BootServices) {
+    test_watchdog(bt);
+}
+
+fn test_watchdog(bt: &BootServices) {
+    bt.set_watchdog_timer(0, 0, 0, ptr::null_mut());
+}

--- a/uefi-test-runner/src/boot/mod.rs
+++ b/uefi-test-runner/src/boot/mod.rs
@@ -2,6 +2,8 @@ use uefi::table::boot::BootServices;
 
 pub fn test(bt: &BootServices) {
     memory::test(bt);
+    misc::test(bt);
 }
 
 mod memory;
+mod misc;


### PR DESCRIPTION
This implements the `set_watchdog_timer` function and correspondent test.