### PR TITLE
Mark CopyMem and SetMem as unsafe

### DIFF
--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -287,12 +287,20 @@ impl BootServices {
     }
 
     /// Copies memory from source to destination. The buffers can overlap.
-    pub fn memmove(&self, dest: *mut u8, src: *const u8, size: usize) {
+    ///
+    /// This function is unsafe as it can be used to violate most safety
+    /// invariants of the Rust type system.
+    ///
+    pub unsafe fn memmove(&self, dest: *mut u8, src: *const u8, size: usize) {
         (self.copy_mem)(dest, src, size);
     }
 
     /// Sets a buffer to a certain value.
-    pub fn memset(&self, buffer: *mut u8, size: usize, value: u8) {
+    ///
+    /// This function is unsafe as it can be used to violate most safety
+    /// invariants of the Rust type system.
+    ///
+    pub unsafe fn memset(&self, buffer: *mut u8, size: usize, value: u8) {
         (self.set_mem)(buffer, size, value);
     }
 }

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -51,12 +51,12 @@ fn memmove(bt: &BootServices) {
     let mut dest = [0u8; 4];
 
     // Fill the buffer with a value
-    bt.memset(dest.as_mut_ptr(), dest.len(), 1);
+    unsafe { bt.memset(dest.as_mut_ptr(), dest.len(), 1); }
 
     assert_eq!(dest, [1; 4], "Failed to set memory");
 
     // Copy other values on it
-    bt.memmove(dest.as_mut_ptr(), src.as_ptr(), dest.len());
+    unsafe { bt.memmove(dest.as_mut_ptr(), src.as_ptr(), dest.len()); }
 
     assert_eq!(dest, src, "Failed to copy memory");
 }


### PR DESCRIPTION
These functions can be used to violate type-safety, memory-safety and thread-safety, and are in that sense textbook examples of unsafe functions ;)