### PR TITLE
Annotated logs, stdout cleanup, and headless display

### DIFF
--- a/src/proto/console/serial.rs
+++ b/src/proto/console/serial.rs
@@ -64,16 +64,23 @@ impl Serial {
 
     /// Sets the device's new control bits.
     ///
-    /// Not all bits can be modified with this function.
-    /// Only the folowing can be set:
-    ///
-    /// - DATA_TERMINAL_READY
-    /// - REQUEST_TO_SEND
-    /// - HARDWARE_LOOPBACK_ENABLE
-    /// - SOFTWARE_LOOPBACK_ENABLE
-    /// - HARDWARE_FLOW_CONTROL_ENABLE
+    /// Not all bits can be modified with this function. You can use the
+    /// settable_control_bits() method to query which of them are.
     pub fn set_control_bits(&mut self, bits: ControlBits) -> Result<()> {
         (self.set_control_bits)(self, bits).into()
+    }
+
+
+    /// Get a bitmask of the control bits that can be set.
+    ///
+    /// TODO: To be replaced with a constant once Rust has const generics
+    pub fn settable_control_bits() -> ControlBits {
+        // Up to date as of UEFI 2.7 / Serial protocol v1
+        ControlBits::DATA_TERMINAL_READY
+        | ControlBits::REQUEST_TO_SEND
+        | ControlBits::HARDWARE_LOOPBACK_ENABLE
+        | ControlBits::SOFTWARE_LOOPBACK_ENABLE
+        | ControlBits::HARDWARE_FLOW_CONTROL_ENABLE
     }
 
     /// Retrieve the device's current control bits.

--- a/uefi-logger/src/lib.rs
+++ b/uefi-logger/src/lib.rs
@@ -22,6 +22,7 @@ use uefi::proto::console::text::Output;
 extern crate log;
 
 use core::cell::UnsafeCell;
+use core::fmt::{self, Write};
 
 mod writer;
 use self::writer::OutputWriter;
@@ -46,11 +47,10 @@ impl log::Log for Logger {
     }
 
     fn log(&self, record: &log::Record) {
-        let args = record.args();
-
         let writer = unsafe { &mut *self.writer.get() };
-        use core::fmt::Write;
-        writeln!(writer, "{}", args).unwrap();
+        DecoratedLog::write(writer,
+                            record.level(),
+                            record.args()).unwrap();
     }
 
     fn flush(&self) {
@@ -61,3 +61,68 @@ impl log::Log for Logger {
 // The logger is not thread-safe, but the UEFI boot environment only uses one processor.
 unsafe impl Sync for Logger {}
 unsafe impl Send for Logger {}
+
+
+/// Writer wrapper which prints a log level in front of every line of text
+///
+/// This is less easy than it sounds because...
+///
+/// 1. The fmt::Arguments is a rather opaque type, the ~only thing you can do
+///    with it is to hand it to an fmt::Write implementation.
+/// 2. Without using memory allocation, the easy cop-out of writing everything
+///    to a String then post-processing is not available.
+///
+/// Therefore, we need to inject ourselves in the middle of the fmt::Write
+/// machinery and intercept the strings that it sends to the Writer.
+///.
+struct DecoratedLog<'a, W: fmt::Write> {
+    backend: &'a mut W,
+    log_level: log::Level,
+    at_line_start: bool,
+}
+//
+impl<'a, W: fmt::Write> DecoratedLog<'a, W> {
+    // Call this method to print a level-annotated log
+    fn write(writer: &'a mut W,
+             level: log::Level,
+             args: &fmt::Arguments) -> fmt::Result {
+        let mut decorated_writer = Self {
+            backend: writer,
+            log_level: level,
+            at_line_start: true,
+        };
+        writeln!(decorated_writer, "{}", *args)
+    }
+}
+//
+impl<'a, W: fmt::Write> fmt::Write for DecoratedLog<'a, W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        // Split the input string into lines
+        let mut lines = s.lines();
+
+        // The beginning of the input string may actually fall in the middle of
+        // a line of output. We only print the log level if it truly is at the
+        // beginning of a line of output.
+        let first = lines.next().unwrap_or("");
+        if self.at_line_start {
+            write!(self.backend, "{}: ", self.log_level);
+            self.at_line_start = false;
+        }
+        write!(self.backend, "{}", first)?;
+
+        // For the remainder of the line iterator (if any), we know that we are
+        // truly at the beginning of lines of output.
+        for line in lines {
+            write!(self.backend, "\n{}: {}", self.log_level, line);
+        }
+
+        // If the string ends with a newline character, we must 1/propagate it
+        // to the output (it was swallowed by the iteration) and 2/prepare to
+        // write the log level of the beginning of the next line (if any).
+        if let Some('\n') = s.chars().next_back() {
+            writeln!(self.backend);
+            self.at_line_start = true;
+        }
+        Ok(())
+    }
+}

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -40,12 +40,8 @@ pub fn test(bt: &BootServices) {
 
         // Clean up after ourselves
         serial.reset().expect("Could not reset the serial device");
-        let settable_bits = ControlBits::REQUEST_TO_SEND
-                          | ControlBits::DATA_TERMINAL_READY
-                          | ControlBits::HARDWARE_LOOPBACK_ENABLE
-                          | ControlBits::SOFTWARE_LOOPBACK_ENABLE
-                          | ControlBits::HARDWARE_FLOW_CONTROL_ENABLE;
-        serial.set_control_bits(old_ctrl_bits & settable_bits).unwrap();
+        serial.set_control_bits(old_ctrl_bits & Serial::settable_control_bits())
+              .expect("Could not restore the serial device state");
     } else {
         warn!("No serial device found");
     }


### PR DESCRIPTION
These improvements were mostly discussed in #1, with a couple of extra ideas I got since then:

- uefi-logger's output is annotated with the log level on a line-by-line basis.
- Headless vs non-headless QEmu configurations are now much closer to each other. Basically, the only difference is whether QEMU spawns an X11 window with the display or not.
- The Python code intercepts QEMU's output and strips ANSI escape sequences from it before forwarding it to stdout, so the UEFI code cannot mess up your terminal anymore.