### PR TITLE
Use `write_volatile` in the GOP example

### DIFF
--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -161,6 +161,9 @@ impl GraphicsOutput {
     ///
     /// This function is inherently unsafe since the wrong format
     /// could be used by a UEFI app when reading / writting the buffer.
+    ///
+    /// It is also the callers responsibilty to use volatile memory accesses,
+    /// otherwise they could be optimized to nothing.
     pub unsafe fn frame_buffer(&mut self) -> &mut [u8] {
         let data = self.mode.fb_address as *mut u8;
         let len = self.mode.fb_size;

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -1,3 +1,4 @@
+use core::ptr;
 use uefi::proto::console::gop::{BltOp, BltPixel, GraphicsOutput, PixelFormat};
 use uefi::table::boot::BootServices;
 use uefi_exts::BootServicesExt;
@@ -54,14 +55,20 @@ fn draw_fb(gop: &mut GraphicsOutput) {
 
     type PixelWriter<'a> = &'a Fn(&mut [u8], (u8, u8, u8));
     let write_pixel_rgb = |pixel: &mut [u8], (r, g, b)| {
-        pixel[0] = r;
-        pixel[1] = g;
-        pixel[2] = b;
+        let p = pixel.as_mut_ptr();
+        unsafe {
+            ptr::write_volatile(p.offset(0), r);
+            ptr::write_volatile(p.offset(1), g);
+            ptr::write_volatile(p.offset(2), b);
+        }
     };
     let write_pixel_bgr = |pixel: &mut [u8], (r, g, b)| {
-        pixel[0] = b;
-        pixel[1] = g;
-        pixel[2] = r;
+        let p = pixel.as_mut_ptr();
+        unsafe {
+            ptr::write_volatile(p.offset(0), b);
+            ptr::write_volatile(p.offset(1), g);
+            ptr::write_volatile(p.offset(2), r);
+        }
     };
     let write_pixel: PixelWriter = match mi.pixel_format() {
         PixelFormat::RGB => &write_pixel_rgb,


### PR DESCRIPTION
The GOP example wrote to the framebuffer without using `write_volatile`, meaning the compiler was allowed to reorder or discard these writes. This PR fixes that.