### PR TITLE
Improve simple pointer protocol state query

### DIFF
--- a/src/proto/console/pointer/mod.rs
+++ b/src/proto/console/pointer/mod.rs
@@ -27,13 +27,18 @@ impl Pointer {
 
     /// Retrieves the pointer device's current state.
     ///
+    /// Will return None if the state has not changed since the last query.
+    ///
     /// # Errors
-    /// - `NotReady` is returned if the state hasn't changed since the last call.
     /// - `DeviceError` if there was an issue with the pointer device.
-    pub fn state(&self) -> Result<PointerState> {
+    pub fn state(&self) -> Result<Option<PointerState>> {
         let mut pointer_state = unsafe { mem::uninitialized() };
 
-        (self.get_state)(self, &mut pointer_state).into_with(|| pointer_state)
+        match (self.get_state)(self, &mut pointer_state) {
+            Status::Success => Ok(Some(pointer_state)),
+            Status::NotReady => Ok(None),
+            error => Err(error)
+        }
     }
 
     /// Returns a reference to the pointer device information.

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,3 +1,4 @@
+use uefi::prelude::*;
 use uefi::proto::console::pointer::Pointer;
 use uefi::table::boot::BootServices;
 
@@ -12,11 +13,11 @@ pub fn test(bt: &BootServices) {
             .reset(false)
             .expect("Failed to reset pointer device");
 
-        if let Ok(state) = pointer.state() {
-            info!("Pointer State: {:#?}", state);
-        } else {
-            error!("Failed to retrieve pointer state");
-        }
+        match pointer.state() {
+            Ok(state) => info!("Pointer State: {:#?}", state),
+            Err(Status::NotReady) => info!("Pointer state has not changed"),
+            Err(e) => panic!("Failed to retrieve pointer state ({:?})", e),
+        };
     } else {
         warn!("No pointer device found");
     }

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,4 +1,3 @@
-use uefi::prelude::*;
 use uefi::proto::console::pointer::Pointer;
 use uefi::table::boot::BootServices;
 
@@ -13,11 +12,12 @@ pub fn test(bt: &BootServices) {
             .reset(false)
             .expect("Failed to reset pointer device");
 
-        match pointer.state() {
-            Ok(state) => info!("Pointer State: {:#?}", state),
-            Err(Status::NotReady) => info!("Pointer state has not changed"),
-            Err(e) => panic!("Failed to retrieve pointer state ({:?})", e),
-        };
+        let state = pointer.state().expect("Failed to retrieve pointer state");
+        if let Some(state) = state {
+            info!("New pointer State: {:#?}", state);
+        } else {
+            info!("Pointer state has not changed since the last query");
+        }
     } else {
         warn!("No pointer device found");
     }


### PR DESCRIPTION
The associated test used to print an error on every run because the Status::NotReady output was incorrectly interpreted as an error. In the context of this function, it means that the pointer state has not changed since the last query, which is normal.

Since this output is not really an error, I think it is better modeled by returning an optional pointer status, so I changed that in simple pointer protocol interface.