### PR TITLE
Handle UEFI warnings more cleanly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1"
+log = { version = "0.4", default-features = false }
 ucs2 = "0.1"
 
 [workspace]

--- a/src/error/completion.rs
+++ b/src/error/completion.rs
@@ -23,7 +23,7 @@ impl<T> Completion<T> {
     }
 
     /// Access the inner value, logging the warning if there is any
-    pub fn value(self) -> T {
+    pub fn log(self) -> T {
         match self {
             Completion::Success(res) => res,
             Completion::Warning(res, stat) => {

--- a/src/error/completion.rs
+++ b/src/error/completion.rs
@@ -1,0 +1,99 @@
+use super::Status;
+use log::warn;
+
+/// This type is used when an UEFI operation has completed, but some non-fatal
+/// problems may have been encountered along the way
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Completion<T> {
+    /// The operation completed without problems
+    Success(T),
+
+    /// The operation completed, but some non-fatal issues were encountered
+    Warning(T, Status),
+}
+
+impl<T> Completion<T> {
+    /// Split the completion into a (status, value) pair
+    pub fn split(self) -> (T, Status) {
+        match self {
+            Completion::Success(res) => (res, Status::SUCCESS),
+            Completion::Warning(res, stat) => (res, stat),
+        }
+    }
+
+    /// Access the inner value, logging the warning if there is any
+    pub fn value(self) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(res, stat) => {
+                warn!("Encountered UEFI warning: {:?}", stat);
+                res
+            }
+        }
+    }
+
+    /// Assume that no warning occured, panic if not
+    pub fn unwrap(self) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(_, w) => {
+                unwrap_failed("Called `Completion::unwrap()` on a `Warning` value", w)
+            }
+        }
+    }
+
+    /// Assume that no warning occured, panic with provided message if not
+    pub fn expect(self, msg: &str) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(_, w) => unwrap_failed(msg, w),
+        }
+    }
+
+    /// Transform the inner value without unwrapping the Completion
+    pub fn map<U>(self, f: impl Fn(T) -> U) -> Completion<U> {
+        match self {
+            Completion::Success(res) => Completion::Success(f(res)),
+            Completion::Warning(res, stat) => Completion::Warning(f(res), stat),
+        }
+    }
+
+    /// Merge this completion with a success or warning status
+    ///
+    /// Since this type only has storage for one warning, if two warnings must
+    /// be stored, one of them will be spilled into the logs.
+    ///
+    pub fn with_warning(self, extra_stat: Status) -> Self {
+        match self {
+            Completion::Success(res) => {
+                if extra_stat.is_success() {
+                    Completion::Success(res)
+                } else {
+                    Completion::Warning(res, extra_stat)
+                }
+            }
+            Completion::Warning(res, stat) => {
+                if extra_stat.is_success() {
+                    Completion::Warning(res, stat)
+                } else {
+                    warn!("Encountered UEFI warning {:?}", stat);
+                    Completion::Warning(res, extra_stat)
+                }
+            }
+        }
+    }
+}
+
+impl<T> From<T> for Completion<T> {
+    fn from(res: T) -> Self {
+        Completion::Success(res)
+    }
+}
+
+// This is a separate function to reduce the code size of the methods
+#[inline(never)]
+#[cold]
+fn unwrap_failed(msg: &str, warning: Status) -> ! {
+    panic!("{}: {:?}", msg, warning)
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,106 +1,48 @@
-use core::result;
-use log::warn;
-
 /// Definition of UEFI's standard status codes
 mod status;
 pub use self::status::Status;
 
-/// This type is used when an UEFI operation has completed, but some non-fatal
-/// problems may have been encountered along the way
-#[must_use]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Completion<T> {
-    /// The operation completed without problems
-    Success(T),
-
-    /// The operation completed, but some non-fatal issues were encountered
-    Warning(T, Status),
-}
-
-impl<T> Completion<T> {
-    /// Split the completion into a (status, value) pair
-    pub fn split(self) -> (T, Status) {
-        match self {
-            Completion::Success(res) => (res, Status::SUCCESS),
-            Completion::Warning(res, stat) => (res, stat),
-        }
-    }
-
-    /// Access the inner value, logging the warning if there is any
-    pub fn value(self) -> T {
-        match self {
-            Completion::Success(res) => res,
-            Completion::Warning(res, stat) => {
-                warn!("Encountered UEFI warning: {:?}", stat);
-                res
-            }
-        }
-    }
-
-    /// Assume that no warning occured, panic if not
-    pub fn unwrap(self) -> T {
-        match self {
-            Completion::Success(res) => res,
-            Completion::Warning(_, w) => {
-                unwrap_failed("Called `Completion::unwrap()` on a `Warning` value", w)
-            }
-        }
-    }
-
-    /// Assume that no warning occured, panic with provided message if not
-    pub fn expect(self, msg: &str) -> T {
-        match self {
-            Completion::Success(res) => res,
-            Completion::Warning(_, w) => unwrap_failed(msg, w),
-        }
-    }
-
-    /// Transform the inner value without unwrapping the Completion
-    pub fn map<U>(self, f: impl Fn(T) -> U) -> Completion<U> {
-        match self {
-            Completion::Success(res) => Completion::Success(f(res)),
-            Completion::Warning(res, stat) => Completion::Warning(f(res), stat),
-        }
-    }
-
-    /// Merge this completion with a success or warning status
-    ///
-    /// Since this type only has storage for one warning, if two warnings must
-    /// be stored, one of them will be spilled into the logs.
-    ///
-    pub fn with_warning(self, extra_stat: Status) -> Self {
-        match self {
-            Completion::Success(res) => {
-                if extra_stat.is_success() {
-                    Completion::Success(res)
-                } else {
-                    Completion::Warning(res, extra_stat)
-                }
-            }
-            Completion::Warning(res, stat) => {
-                if extra_stat.is_success() {
-                    Completion::Warning(res, stat)
-                } else {
-                    warn!("Encountered UEFI warning {:?}", stat);
-                    Completion::Warning(res, extra_stat)
-                }
-            }
-        }
-    }
-}
-
-impl<T> From<T> for Completion<T> {
-    fn from(res: T) -> Self {
-        Completion::Success(res)
-    }
-}
-
-// This is a separate function to reduce the code size of the methods
-#[inline(never)]
-#[cold]
-fn unwrap_failed(msg: &str, warning: Status) -> ! {
-    panic!("{}: {:?}", msg, warning)
-}
+/// Completions are used to model operations which have completed, but may have
+/// encountered non-fatal errors ("warnings") along the way
+mod completion;
+pub use self::completion::Completion;
 
 /// Return type of many UEFI functions.
-pub type Result<T> = result::Result<Completion<T>, Status>;
+pub type Result<T> = core::result::Result<Completion<T>, Status>;
+
+/// Extension trait for Result which helps dealing with UEFI's warnings
+pub trait ResultExt<T> {
+    /// Treat warnings as errors
+    fn warn_error(self) -> core::result::Result<T, Status>;
+
+    /// Ignore warnings, keepint a trace of them in the logs
+    fn warn_log(self) -> core::result::Result<T, Status>;
+
+    /// Expect success without warnings, panic otherwise
+    fn warn_unwrap(self) -> T;
+
+    /// Expect success without warnings, panic with provided message otherwise
+    fn warn_expect(self, msg: &str) -> T;
+}
+
+impl<T> ResultExt<T> for Result<T> {
+    fn warn_error(self) -> core::result::Result<T, Status> {
+        match self {
+            Ok(Completion::Success(v)) => Ok(v),
+            Ok(Completion::Warning(_, s)) => Err(s),
+            Err(s) => Err(s),
+        }
+    }
+
+    fn warn_log(self) -> core::result::Result<T, Status> {
+        self.map(|completion| completion.value())
+    }
+
+    fn warn_unwrap(self) -> T {
+        self.unwrap().unwrap()
+    }
+
+    fn warn_expect(self, msg: &str) -> T {
+        self.expect(msg).expect(msg)
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -33,7 +33,7 @@ impl<T> Completion<T> {
             Completion::Warning(res, stat) => {
                 warn!("Encountered UEFI warning: {:?}", stat);
                 res
-            },
+            }
         }
     }
 
@@ -41,8 +41,9 @@ impl<T> Completion<T> {
     pub fn unwrap(self) -> T {
         match self {
             Completion::Success(res) => res,
-            Completion::Warning(_, w) =>
-                unwrap_failed("Called `Completion::unwrap()` on a `Warning` value", w),
+            Completion::Warning(_, w) => {
+                unwrap_failed("Called `Completion::unwrap()` on a `Warning` value", w)
+            }
         }
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -8,6 +8,7 @@ pub use self::status::Status;
 /// This type is used when an UEFI operation has completed, but some non-fatal
 /// problems may have been encountered along the way
 #[must_use]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Completion<T> {
     /// The operation completed without problems
     Success(T),
@@ -26,13 +27,21 @@ impl<T> Completion<T> {
     }
 
     /// Access the inner value, logging the warning if there is any
-    pub fn unwrap(self) -> T {
+    pub fn value(self) -> T {
         match self {
             Completion::Success(res) => res,
             Completion::Warning(res, stat) => {
-                warn!("Encountered UEFI warning {:?}", stat);
+                warn!("Encountered UEFI warning: {:?}", stat);
                 res
             },
+        }
+    }
+
+    /// Assume that no warning occured, panic with provided message if not
+    pub fn expect(self, msg: &str) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(_, w) => panic!("{}: {:?}", msg, w),
         }
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -15,7 +15,7 @@ pub trait ResultExt<T> {
     /// Treat warnings as errors
     fn warn_err(self) -> core::result::Result<T, Status>;
 
-    /// Ignore warnings, keepint a trace of them in the logs
+    /// Ignore warnings, keeping a trace of them in the logs
     fn warn_log(self) -> core::result::Result<T, Status>;
 
     /// Expect success without warnings, panic otherwise

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -17,7 +17,7 @@ pub enum Completion<T> {
 }
 
 impl<T> Completion<T> {
-    /// Split the complation into a (status, value) pair
+    /// Split the completion into a (status, value) pair
     pub fn split(self) -> (T, Status) {
         match self {
             Completion::Success(res) => (res, Status::SUCCESS),
@@ -50,7 +50,6 @@ impl<T> Completion<T> {
     /// be stored, one of them will be spilled into the logs.
     ///
     pub fn with_warning(self, extra_stat: Status) -> Self {
-        assert!(!extra_stat.is_error(), "Completions do not handle error status");
         match self {
             Completion::Success(res) => {
                 if extra_stat.is_success() {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,8 +1,82 @@
 use core::result;
+use log::warn;
 
 /// Definition of UEFI's standard status codes
 mod status;
 pub use self::status::Status;
 
+/// This type is used when an UEFI operation has completed, but some non-fatal
+/// problems may have been encountered along the way
+#[must_use]
+pub enum Completion<T> {
+    /// The operation completed without problems
+    Success(T),
+
+    /// The operation completed, but some non-fatal issues were encountered
+    Warning(T, Status),
+}
+
+impl<T> Completion<T> {
+    /// Split the complation into a (status, value) pair
+    pub fn split(self) -> (T, Status) {
+        match self {
+            Completion::Success(res) => (res, Status::SUCCESS),
+            Completion::Warning(res, stat) => (res, stat),
+        }
+    }
+
+    /// Access the inner value, logging the warning if there is any
+    pub fn unwrap(self) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(res, stat) => {
+                warn!("Encountered UEFI warning {:?}", stat);
+                res
+            },
+        }
+    }
+
+    /// Transform the inner value without unwrapping the Completion
+    pub fn map<U>(self, f: impl Fn(T) -> U) -> Completion<U> {
+        match self {
+            Completion::Success(res) => Completion::Success(f(res)),
+            Completion::Warning(res, stat) => Completion::Warning(f(res), stat),
+        }
+    }
+
+    /// Merge this completion with a success or warning status
+    ///
+    /// Since this type only has storage for one warning, if two warnings must
+    /// be stored, one of them will be spilled into the logs.
+    ///
+    pub fn with_warning(self, extra_stat: Status) -> Self {
+        assert!(!extra_stat.is_error(), "Completions do not handle error status");
+        match self {
+            Completion::Success(res) => {
+                if extra_stat.is_success() {
+                    Completion::Success(res)
+                } else {
+                    Completion::Warning(res, extra_stat)
+                }
+            }
+            Completion::Warning(res, stat) => {
+                if extra_stat.is_success() {
+                    Completion::Warning(res, stat)
+                } else {
+                    warn!("Encountered UEFI warning {:?}", stat);
+                    Completion::Warning(res, extra_stat)
+                }
+            }
+        }
+    }
+
+}
+
+impl<T> From<T> for Completion<T> {
+    fn from(res: T) -> Self {
+        Completion::Success(res)
+    }
+}
+
 /// Return type of many UEFI functions.
-pub type Result<T> = result::Result<T, Status>;
+pub type Result<T> = result::Result<Completion<T>, Status>;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -13,23 +13,23 @@ pub type Result<T> = core::result::Result<Completion<T>, Status>;
 /// Extension trait for Result which helps dealing with UEFI's warnings
 pub trait ResultExt<T> {
     /// Treat warnings as errors
-    fn warn_err(self) -> core::result::Result<T, Status>;
+    fn warning_as_error(self) -> core::result::Result<T, Status>;
 
     /// Ignore warnings, keeping a trace of them in the logs
-    fn warn_log(self) -> core::result::Result<T, Status>;
+    fn log_warning(self) -> core::result::Result<T, Status>;
 
     /// Expect success without warnings, panic otherwise
-    fn warn_unwrap(self) -> T;
+    fn unwrap_success(self) -> T;
 
     /// Expect success without warnings, panic with provided message otherwise
-    fn warn_expect(self, msg: &str) -> T;
+    fn expect_success(self, msg: &str) -> T;
 
     /// Transform the inner output, if any
-    fn warn_map<U>(self, f: impl Fn(T) -> U) -> Result<U>;
+    fn map_inner<U>(self, f: impl Fn(T) -> U) -> Result<U>;
 }
 
 impl<T> ResultExt<T> for Result<T> {
-    fn warn_err(self) -> core::result::Result<T, Status> {
+    fn warning_as_error(self) -> core::result::Result<T, Status> {
         match self {
             Ok(Completion::Success(v)) => Ok(v),
             Ok(Completion::Warning(_, s)) => Err(s),
@@ -37,19 +37,19 @@ impl<T> ResultExt<T> for Result<T> {
         }
     }
 
-    fn warn_log(self) -> core::result::Result<T, Status> {
+    fn log_warning(self) -> core::result::Result<T, Status> {
         self.map(|completion| completion.log())
     }
 
-    fn warn_unwrap(self) -> T {
+    fn unwrap_success(self) -> T {
         self.unwrap().unwrap()
     }
 
-    fn warn_expect(self, msg: &str) -> T {
+    fn expect_success(self, msg: &str) -> T {
         self.expect(msg).expect(msg)
     }
 
-    fn warn_map<U>(self, f: impl Fn(T) -> U) -> Result<U> {
+    fn map_inner<U>(self, f: impl Fn(T) -> U) -> Result<U> {
         self.map(|completion| completion.map(f))
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -37,11 +37,20 @@ impl<T> Completion<T> {
         }
     }
 
+    /// Assume that no warning occured, panic if not
+    pub fn unwrap(self) -> T {
+        match self {
+            Completion::Success(res) => res,
+            Completion::Warning(_, w) =>
+                unwrap_failed("Called `Completion::unwrap()` on a `Warning` value", w),
+        }
+    }
+
     /// Assume that no warning occured, panic with provided message if not
     pub fn expect(self, msg: &str) -> T {
         match self {
             Completion::Success(res) => res,
-            Completion::Warning(_, w) => panic!("{}: {:?}", msg, w),
+            Completion::Warning(_, w) => unwrap_failed(msg, w),
         }
     }
 
@@ -77,13 +86,19 @@ impl<T> Completion<T> {
             }
         }
     }
-
 }
 
 impl<T> From<T> for Completion<T> {
     fn from(res: T) -> Self {
         Completion::Success(res)
     }
+}
+
+// This is a separate function to reduce the code size of the methods
+#[inline(never)]
+#[cold]
+fn unwrap_failed(msg: &str, warning: Status) -> ! {
+    panic!("{}: {:?}", msg, warning)
 }
 
 /// Return type of many UEFI functions.

--- a/src/error/status.rs
+++ b/src/error/status.rs
@@ -1,4 +1,4 @@
-use super::Result;
+use super::{Completion, Result};
 use core::ops;
 use ucs2;
 
@@ -129,9 +129,10 @@ impl Status {
     where
         F: FnOnce() -> T,
     {
-        // FIXME: Is that the best way to handle warnings?
         if self.is_success() {
-            Ok(f())
+            Ok(Completion::Success(f()))
+        } else if self.is_warning() {
+            Ok(Completion::Warning(f(), self))
         } else {
             Err(self)
         }
@@ -146,7 +147,7 @@ impl Into<Result<()>> for Status {
 }
 
 impl ops::Try for Status {
-    type Ok = ();
+    type Ok = Completion<()>;
     type Error = Status;
 
     fn into_result(self) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! therefore all the network protocols will be unavailable.
 
 #![feature(optin_builtin_traits)]
-#![feature(tool_lints)]
 #![feature(try_trait)]
 #![no_std]
 // Enable some additional warnings and lints.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod data_types;
 pub use self::data_types::{Event, Guid, Handle};
 
 mod error;
-pub use self::error::{Completion, Result, Status};
+pub use self::error::{Completion, Result, ResultExt, Status};
 
 pub mod table;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! therefore all the network protocols will be unavailable.
 
 #![feature(optin_builtin_traits)]
-#![feature(min_const_fn)]
 #![feature(tool_lints)]
 #![feature(try_trait)]
 #![no_std]
@@ -37,7 +36,7 @@ mod data_types;
 pub use self::data_types::{Event, Guid, Handle};
 
 mod error;
-pub use self::error::{Result, Status};
+pub use self::error::{Completion, Result, Status};
 
 pub mod table;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 //!
 //! This includes the system table types, `Status` codes, etc.
 
-pub use crate::{Completion, Result, Status};
+pub use crate::Status;
 
 // Import the basic table types.
 pub use crate::table::{boot::BootServices, runtime::RuntimeServices, SystemTable};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 //!
 //! This includes the system table types, `Status` codes, etc.
 
-pub use crate::Status;
+pub use crate::{Completion, Result, Status};
 
 // Import the basic table types.
 pub use crate::table::{boot::BootServices, runtime::RuntimeServices, SystemTable};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 //!
 //! This includes the system table types, `Status` codes, etc.
 
-pub use crate::Status;
+pub use crate::{ResultExt, Status};
 
 // Import the basic table types.
 pub use crate::table::{boot::BootServices, runtime::RuntimeServices, SystemTable};

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -24,7 +24,7 @@
 //! but in practice there might be some extra padding used for efficiency.
 
 use core::{ptr, slice};
-use crate::{Result, Status};
+use crate::{Completion, Result, Status};
 
 /// Provides access to the video hardware's frame buffer.
 ///
@@ -71,7 +71,7 @@ impl GraphicsOutput {
     }
 
     /// Returns information about all available graphics modes.
-    pub fn modes<'a>(&'a self) -> impl Iterator<Item = Mode> + 'a {
+    pub fn modes<'a>(&'a self) -> impl Iterator<Item = Completion<Mode>> + 'a {
         ModeIter {
             gop: self,
             current: 0,
@@ -397,7 +397,7 @@ struct ModeIter<'a> {
 }
 
 impl<'a> Iterator for ModeIter<'a> {
-    type Item = Mode;
+    type Item = Completion<Mode>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.current;

--- a/src/proto/console/pointer/mod.rs
+++ b/src/proto/console/pointer/mod.rs
@@ -37,9 +37,8 @@ impl Pointer {
         let mut pointer_state = unsafe { mem::uninitialized() };
 
         match (self.get_state)(self, &mut pointer_state) {
-            Status::SUCCESS => Ok(Some(pointer_state)),
-            Status::NOT_READY => Ok(None),
-            error => Err(error),
+            Status::NOT_READY => Ok(None.into()),
+            other => other.into_with(|| Some(pointer_state)),
         }
     }
 

--- a/src/proto/console/serial.rs
+++ b/src/proto/console/serial.rs
@@ -86,12 +86,7 @@ impl Serial {
     pub fn write(&mut self, data: &[u8]) -> Result<usize> {
         let mut buffer_size = data.len();
 
-        let status = (self.write)(self, &mut buffer_size, data.as_ptr());
-
-        match status {
-            Status::SUCCESS | Status::TIMEOUT => Ok(buffer_size),
-            err => Err(err),
-        }
+        (self.write)(self, &mut buffer_size, data.as_ptr()).into_with(|| buffer_size)
     }
 
     /// Reads data from this device.
@@ -102,12 +97,7 @@ impl Serial {
     pub fn read(&mut self, data: &mut [u8]) -> Result<usize> {
         let mut buffer_size = data.len();
 
-        let status = (self.read)(self, &mut buffer_size, data.as_mut_ptr());
-
-        match status {
-            Status::SUCCESS | Status::TIMEOUT => Ok(buffer_size),
-            err => Err(err),
-        }
+        (self.read)(self, &mut buffer_size, data.as_mut_ptr()).into_with(|| buffer_size)
     }
 
     /// Returns the current I/O mode.

--- a/src/proto/console/text/input.rs
+++ b/src/proto/console/text/input.rs
@@ -35,7 +35,7 @@ impl Input {
 
         match (self.read_key_stroke)(self, &mut key) {
             Status::NOT_READY => Ok(None.into()),
-            other => other.into_with(|| Some(key))
+            other => other.into_with(|| Some(key)),
         }
     }
 

--- a/src/proto/console/text/input.rs
+++ b/src/proto/console/text/input.rs
@@ -34,9 +34,8 @@ impl Input {
         let mut key = unsafe { mem::uninitialized() };
 
         match (self.read_key_stroke)(self, &mut key) {
-            Status::SUCCESS => Ok(Some(key)),
-            Status::NOT_READY => Ok(None),
-            error => Err(error),
+            Status::NOT_READY => Ok(None.into()),
+            other => other.into_with(|| Some(key))
         }
     }
 

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -1,6 +1,6 @@
 use core::fmt;
-use crate::{Completion, Result, Status};
 use crate::prelude::*;
+use crate::{Completion, Result, Status};
 
 /// Interface for text-based output devices.
 ///
@@ -86,7 +86,8 @@ impl Output {
     /// Returns the the current text mode.
     pub fn current_mode(&self) -> Result<OutputMode> {
         let index = self.data.mode;
-        self.query_mode(index).warn_map(|dims| OutputMode { index, dims })
+        self.query_mode(index)
+            .warn_map(|dims| OutputMode { index, dims })
     }
 
     /// Make the cursor visible or invisible.
@@ -147,7 +148,9 @@ impl fmt::Write for Output {
             buf[*i] = 0;
             *i = 0;
 
-            self.output_string(buf.as_ptr()).warn_err().map_err(|_| fmt::Error)
+            self.output_string(buf.as_ptr())
+                .warn_err()
+                .map_err(|_| fmt::Error)
         };
 
         // This closure converts a character to UCS-2 and adds it to the buffer,

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -159,8 +159,9 @@ impl fmt::Write for Output {
             i += 1;
 
             if i == BUF_SIZE {
-                flush_buffer(&mut buf, &mut i).map_err(|_| ucs2::Error::BufferOverflow)
-                                              .map(|completion| completion.value())
+                flush_buffer(&mut buf, &mut i)
+                    .map_err(|_| ucs2::Error::BufferOverflow)
+                    .map(|completion| completion.value())
             } else {
                 Ok(())
             }

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -160,7 +160,7 @@ impl fmt::Write for Output {
 
             if i == BUF_SIZE {
                 flush_buffer(&mut buf, &mut i).map_err(|_| ucs2::Error::BufferOverflow)
-                                              .map(|completion| completion.unwrap())
+                                              .map(|completion| completion.value())
             } else {
                 Ok(())
             }
@@ -178,7 +178,7 @@ impl fmt::Write for Output {
         ucs2::encode_with(s, add_ch).map_err(|_| fmt::Error)?;
 
         // Flush the remainder of the buffer
-        flush_buffer(&mut buf, &mut i).map(|completion| completion.unwrap())
+        flush_buffer(&mut buf, &mut i).map(|completion| completion.value())
     }
 }
 

--- a/src/proto/console/text/output.rs
+++ b/src/proto/console/text/output.rs
@@ -87,7 +87,7 @@ impl Output {
     pub fn current_mode(&self) -> Result<OutputMode> {
         let index = self.data.mode;
         self.query_mode(index)
-            .warn_map(|dims| OutputMode { index, dims })
+            .map_inner(|dims| OutputMode { index, dims })
     }
 
     /// Make the cursor visible or invisible.
@@ -149,7 +149,7 @@ impl fmt::Write for Output {
             *i = 0;
 
             self.output_string(buf.as_ptr())
-                .warn_err()
+                .warning_as_error()
                 .map_err(|_| fmt::Error)
         };
 

--- a/src/proto/media/file.rs
+++ b/src/proto/media/file.rs
@@ -164,7 +164,7 @@ impl<'a> Drop for File<'a> {
     fn drop(&mut self) {
         let result: Result<()> = (self.inner.close)(self.inner).into();
         // The spec says this always succeeds.
-        result.warn_expect("Failed to close file");
+        result.expect_success("Failed to close file");
     }
 }
 

--- a/src/proto/media/file.rs
+++ b/src/proto/media/file.rs
@@ -7,8 +7,8 @@
 
 use bitflags::bitflags;
 use core::mem;
-use crate::{Result, Status};
 use crate::prelude::*;
+use crate::{Result, Status};
 use ucs2;
 
 /// A file represents an abstraction of some contiguous block of data residing

--- a/src/proto/media/file.rs
+++ b/src/proto/media/file.rs
@@ -163,7 +163,7 @@ impl<'a> Drop for File<'a> {
     fn drop(&mut self) {
         let result: Result<()> = (self.inner.close)(self.inner).into();
         // The spec says this always succeeds.
-        result.expect("Failed to close file");
+        result.expect("Failed to close file").unwrap();
     }
 }
 

--- a/src/proto/media/file.rs
+++ b/src/proto/media/file.rs
@@ -8,6 +8,7 @@
 use bitflags::bitflags;
 use core::mem;
 use crate::{Result, Status};
+use crate::prelude::*;
 use ucs2;
 
 /// A file represents an abstraction of some contiguous block of data residing
@@ -163,7 +164,7 @@ impl<'a> Drop for File<'a> {
     fn drop(&mut self) {
         let result: Result<()> = (self.inner.close)(self.inner).into();
         // The spec says this always succeeds.
-        result.expect("Failed to close file").value();
+        result.warn_expect("Failed to close file");
     }
 }
 

--- a/src/proto/media/file.rs
+++ b/src/proto/media/file.rs
@@ -163,7 +163,7 @@ impl<'a> Drop for File<'a> {
     fn drop(&mut self) {
         let result: Result<()> = (self.inner.close)(self.inner).into();
         // The spec says this always succeeds.
-        result.expect("Failed to close file").unwrap();
+        result.expect("Failed to close file").value();
     }
 }
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -180,7 +180,8 @@ impl BootServices {
             &mut map_key,
             &mut entry_size,
             &mut entry_version,
-        ).into_with(move || {
+        )
+        .into_with(move || {
             let len = map_size / entry_size;
             let iter = MemoryMapIter {
                 buffer,

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -14,7 +14,6 @@
 #![no_std]
 // Custom allocators are currently unstable.
 #![feature(allocator_api)]
-#![feature(tool_lints)]
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -18,6 +18,7 @@
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;
 
+use uefi::prelude::*;
 use uefi::table::boot::{BootServices, MemoryType};
 
 /// Reference to the boot services table, used to call the pool memory allocation functions.
@@ -52,14 +53,15 @@ unsafe impl GlobalAlloc for Allocator {
         } else {
             boot_services()
                 .allocate_pool(mem_ty, size)
-                .map(|addr| addr.value() as *mut _)
+                .warn_err()
+                .map(|addr| addr as *mut _)
                 .unwrap_or(ptr::null_mut())
         }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         let addr = ptr as usize;
-        boot_services().free_pool(addr).unwrap().value();
+        boot_services().free_pool(addr).warn_err().unwrap();
     }
 }
 

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -53,7 +53,7 @@ unsafe impl GlobalAlloc for Allocator {
         } else {
             boot_services()
                 .allocate_pool(mem_ty, size)
-                .warn_err()
+                .warning_as_error()
                 .map(|addr| addr as *mut _)
                 .unwrap_or(ptr::null_mut())
         }
@@ -61,7 +61,7 @@ unsafe impl GlobalAlloc for Allocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         let addr = ptr as usize;
-        boot_services().free_pool(addr).warn_err().unwrap();
+        boot_services().free_pool(addr).warning_as_error().unwrap();
     }
 }
 

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -52,14 +52,14 @@ unsafe impl GlobalAlloc for Allocator {
         } else {
             boot_services()
                 .allocate_pool(mem_ty, size)
-                .map(|addr| addr.unwrap() as *mut _)
+                .map(|addr| addr.value() as *mut _)
                 .unwrap_or(ptr::null_mut())
         }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         let addr = ptr as usize;
-        boot_services().free_pool(addr).unwrap().unwrap();
+        boot_services().free_pool(addr).unwrap().value();
     }
 }
 

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -53,14 +53,14 @@ unsafe impl GlobalAlloc for Allocator {
         } else {
             boot_services()
                 .allocate_pool(mem_ty, size)
-                .map(|addr| addr as *mut _)
+                .map(|addr| addr.unwrap() as *mut _)
                 .unwrap_or(ptr::null_mut())
         }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         let addr = ptr as usize;
-        boot_services().free_pool(addr).unwrap();
+        boot_services().free_pool(addr).unwrap().unwrap();
     }
 }
 

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -20,8 +20,7 @@ impl BootServicesExt for BootServices {
         let search_type = SearchType::from_proto::<P>();
 
         // Determine how much we need to allocate.
-        let (buffer_size, warn1) = self.locate_handle(search_type, None)?
-                                       .split();
+        let (buffer_size, warn1) = self.locate_handle(search_type, None)?.split();
 
         // Allocate a large enough buffer.
         let mut buffer = Vec::with_capacity(buffer_size);
@@ -31,22 +30,24 @@ impl BootServicesExt for BootServices {
         }
 
         // Perform the search.
-        let (buffer_size, warn2) = self.locate_handle(search_type, Some(&mut buffer))?
-                                       .split();
+        let (buffer_size, warn2) = self.locate_handle(search_type, Some(&mut buffer))?.split();
 
         // Once the vector has been filled, update its size.
         unsafe {
             buffer.set_len(buffer_size);
         }
 
-        warn1.into_with(|| buffer).map(|completion| completion.with_warning(warn2))
+        warn1
+            .into_with(|| buffer)
+            .map(|completion| completion.with_warning(warn2))
     }
 
     fn find_protocol<P: Protocol>(&self) -> Option<NonNull<P>> {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.
-            .ok()?.value()
+            .ok()?
+            .value()
             // Using the `find_handles` function might not return _only_ compatible protocols.
             // We have to retrieve them all and find one that works.
             .iter()

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -1,7 +1,7 @@
+use uefi::prelude::*;
 use uefi::proto::Protocol;
 use uefi::table::boot::{BootServices, SearchType};
 use uefi::{Handle, Result};
-use uefi::prelude::*;
 
 use core::ptr::NonNull;
 use crate::alloc::vec::Vec;

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -21,7 +21,7 @@ impl BootServicesExt for BootServices {
         let search_type = SearchType::from_proto::<P>();
 
         // Determine how much we need to allocate.
-        let (buffer_size, warn1) = self.locate_handle(search_type, None)?.split();
+        let (buffer_size, status1) = self.locate_handle(search_type, None)?.split();
 
         // Allocate a large enough buffer.
         let mut buffer = Vec::with_capacity(buffer_size);
@@ -31,23 +31,23 @@ impl BootServicesExt for BootServices {
         }
 
         // Perform the search.
-        let (buffer_size, warn2) = self.locate_handle(search_type, Some(&mut buffer))?.split();
+        let (buffer_size, status2) = self.locate_handle(search_type, Some(&mut buffer))?.split();
 
         // Once the vector has been filled, update its size.
         unsafe {
             buffer.set_len(buffer_size);
         }
 
-        warn1
+        status1
             .into_with(|| buffer)
-            .map(|completion| completion.with_warning(warn2))
+            .map(|completion| completion.with_status(status2))
     }
 
     fn find_protocol<P: Protocol>(&self) -> Option<NonNull<P>> {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.
-            .warn_err()
+            .warning_as_error()
             .ok()?
             // Using the `find_handles` function might not return _only_ compatible protocols.
             // We have to retrieve them all and find one that works.

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -46,7 +46,7 @@ impl BootServicesExt for BootServices {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.
-            .ok()?.unwrap()
+            .ok()?.value()
             // Using the `find_handles` function might not return _only_ compatible protocols.
             // We have to retrieve them all and find one that works.
             .iter()

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -1,6 +1,7 @@
 use uefi::proto::Protocol;
 use uefi::table::boot::{BootServices, SearchType};
 use uefi::{Handle, Result};
+use uefi::prelude::*;
 
 use core::ptr::NonNull;
 use crate::alloc::vec::Vec;
@@ -46,8 +47,8 @@ impl BootServicesExt for BootServices {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.
+            .warn_err()
             .ok()?
-            .value()
             // Using the `find_handles` function might not return _only_ compatible protocols.
             // We have to retrieve them all and find one that works.
             .iter()

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -20,7 +20,8 @@ impl BootServicesExt for BootServices {
         let search_type = SearchType::from_proto::<P>();
 
         // Determine how much we need to allocate.
-        let buffer_size = self.locate_handle(search_type, None)?;
+        let (buffer_size, warn1) = self.locate_handle(search_type, None)?
+                                       .split();
 
         // Allocate a large enough buffer.
         let mut buffer = Vec::with_capacity(buffer_size);
@@ -30,21 +31,22 @@ impl BootServicesExt for BootServices {
         }
 
         // Perform the search.
-        let buffer_size = self.locate_handle(search_type, Some(&mut buffer))?;
+        let (buffer_size, warn2) = self.locate_handle(search_type, Some(&mut buffer))?
+                                       .split();
 
         // Once the vector has been filled, update its size.
         unsafe {
             buffer.set_len(buffer_size);
         }
 
-        Ok(buffer)
+        warn1.into_with(|| buffer).map(|completion| completion.with_warning(warn2))
     }
 
     fn find_protocol<P: Protocol>(&self) -> Option<NonNull<P>> {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.
-            .ok()?
+            .ok()?.unwrap()
             // Using the `find_handles` function might not return _only_ compatible protocols.
             // We have to retrieve them all and find one that works.
             .iter()

--- a/uefi-logger/src/lib.rs
+++ b/uefi-logger/src/lib.rs
@@ -15,7 +15,6 @@
 #![warn(missing_docs)]
 #![deny(clippy::all)]
 #![no_std]
-#![feature(tool_lints)]
 
 extern crate uefi;
 use uefi::proto::console::text::Output;

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -1,3 +1,4 @@
+use uefi::prelude::*;
 use uefi::table::boot::{AllocateType, BootServices, MemoryDescriptor, MemoryType};
 
 use core::mem;
@@ -20,8 +21,7 @@ fn allocate_pages(bt: &BootServices) {
     let mem_ty = MemoryType::LOADER_DATA;
     let pgs = bt
         .allocate_pages(ty, mem_ty, 1)
-        .expect("Failed to allocate a page of memory")
-        .expect("Warnings encountered while allocating a page");
+        .warn_expect("Failed to allocate a page of memory");
 
     assert_eq!(pgs % 4096, 0, "Page pointer is not page-aligned");
 
@@ -38,7 +38,7 @@ fn allocate_pages(bt: &BootServices) {
     buf[4095] = 0x23;
 
     // Clean up to avoid memory leaks.
-    bt.free_pages(pgs, 1).unwrap().unwrap();
+    bt.free_pages(pgs, 1).warn_unwrap();
 }
 
 // Simple test to ensure our custom allocator works with the `alloc` crate.
@@ -92,8 +92,7 @@ fn memory_map(bt: &BootServices) {
 
     let (_key, mut desc_iter) = bt
         .memory_map(&mut buffer)
-        .expect("Failed to retrieve UEFI memory map")
-        .expect("Warnings encountered while retrieving memory map");
+        .warn_expect("Failed to retrieve UEFI memory map");
 
     // Ensured we have at least one entry.
     // Real memory maps usually have dozens of entries.

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -20,7 +20,8 @@ fn allocate_pages(bt: &BootServices) {
     let mem_ty = MemoryType::LOADER_DATA;
     let pgs = bt
         .allocate_pages(ty, mem_ty, 1)
-        .expect("Failed to allocate a page of memory");
+        .expect("Failed to allocate a page of memory")
+        .expect("Warnings encountered while allocating a page");
 
     assert_eq!(pgs % 4096, 0, "Page pointer is not page-aligned");
 
@@ -37,7 +38,7 @@ fn allocate_pages(bt: &BootServices) {
     buf[4095] = 0x23;
 
     // Clean up to avoid memory leaks.
-    bt.free_pages(pgs, 1).unwrap();
+    bt.free_pages(pgs, 1).unwrap().unwrap();
 }
 
 // Simple test to ensure our custom allocator works with the `alloc` crate.
@@ -91,7 +92,8 @@ fn memory_map(bt: &BootServices) {
 
     let (_key, mut desc_iter) = bt
         .memory_map(&mut buffer)
-        .expect("Failed to retrieve UEFI memory map");
+        .expect("Failed to retrieve UEFI memory map")
+        .expect("Warnings encountered while retrieving memory map");
 
     // Ensured we have at least one entry.
     // Real memory maps usually have dozens of entries.

--- a/uefi-test-runner/src/boot/memory.rs
+++ b/uefi-test-runner/src/boot/memory.rs
@@ -21,7 +21,7 @@ fn allocate_pages(bt: &BootServices) {
     let mem_ty = MemoryType::LOADER_DATA;
     let pgs = bt
         .allocate_pages(ty, mem_ty, 1)
-        .warn_expect("Failed to allocate a page of memory");
+        .expect_success("Failed to allocate a page of memory");
 
     assert_eq!(pgs % 4096, 0, "Page pointer is not page-aligned");
 
@@ -38,7 +38,7 @@ fn allocate_pages(bt: &BootServices) {
     buf[4095] = 0x23;
 
     // Clean up to avoid memory leaks.
-    bt.free_pages(pgs, 1).warn_unwrap();
+    bt.free_pages(pgs, 1).unwrap_success();
 }
 
 // Simple test to ensure our custom allocator works with the `alloc` crate.
@@ -92,7 +92,7 @@ fn memory_map(bt: &BootServices) {
 
     let (_key, mut desc_iter) = bt
         .memory_map(&mut buffer)
-        .warn_expect("Failed to retrieve UEFI memory map");
+        .expect_success("Failed to retrieve UEFI memory map");
 
     // Ensured we have at least one entry.
     // Real memory maps usually have dozens of entries.

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -7,5 +7,6 @@ pub fn test(bt: &BootServices) {
 fn test_watchdog(bt: &BootServices) {
     // Disable the UEFI watchdog timer
     bt.set_watchdog_timer(0, 0x10000, None)
-        .expect("Could not set watchdog timer");
+        .expect("Could not set watchdog timer")
+        .expect("Warnings encountered while setting watchdog timer");
 }

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -8,5 +8,5 @@ pub fn test(bt: &BootServices) {
 fn test_watchdog(bt: &BootServices) {
     // Disable the UEFI watchdog timer
     bt.set_watchdog_timer(0, 0x10000, None)
-        .warn_expect("Could not set watchdog timer");
+        .expect_success("Could not set watchdog timer");
 }

--- a/uefi-test-runner/src/boot/misc.rs
+++ b/uefi-test-runner/src/boot/misc.rs
@@ -1,3 +1,4 @@
+use uefi::prelude::*;
 use uefi::table::boot::BootServices;
 
 pub fn test(bt: &BootServices) {
@@ -7,6 +8,5 @@ pub fn test(bt: &BootServices) {
 fn test_watchdog(bt: &BootServices) {
     // Disable the UEFI watchdog timer
     bt.set_watchdog_timer(0, 0x10000, None)
-        .expect("Could not set watchdog timer")
-        .expect("Warnings encountered while setting watchdog timer");
+        .warn_expect("Could not set watchdog timer");
 }

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -25,8 +25,7 @@ pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable
     // Reset the console before running all the other tests.
     st.stdout()
         .reset(false)
-        .expect("Failed to reset stdout")
-        .expect("Warnings encountered while resetting stdout");
+        .warn_expect("Failed to reset stdout");
 
     // Ensure the tests are run on a version of UEFI we support.
     check_revision(st.uefi_revision());
@@ -75,30 +74,23 @@ fn check_screenshot(bt: &BootServices, name: &str) {
         io_mode.timeout = 3_000_000;
         serial
             .set_attributes(&io_mode)
-            .expect("Failed to configure serial port timeout")
-            .expect("Warnings encountered while configuring serial port timeout");
+            .warn_expect("Failed to configure serial port timeout");
 
         // Send a screenshot request to the host
         serial
             .write(b"SCREENSHOT: ")
-            .expect("Failed to send request")
-            .expect("Request triggered a warning");
+            .warn_expect("Failed to send request");
         let name_bytes = name.as_bytes();
         serial
             .write(name_bytes)
-            .expect("Failed to send request")
-            .expect("Request triggered a warning");
-        serial
-            .write(b"\n")
-            .expect("Failed to send request")
-            .expect("Request triggered a warning");
+            .warn_expect("Failed to send request");
+        serial.write(b"\n").warn_expect("Failed to send request");
 
         // Wait for the host's acknowledgement before moving forward
         let mut reply = [0; 3];
         serial
             .read(&mut reply[..])
-            .expect("Failed to read host reply")
-            .expect("Request triggered a warning");
+            .warn_expect("Failed to read host reply");
 
         assert_eq!(&reply[..], b"OK\n", "Unexpected screenshot request reply");
     } else {
@@ -111,7 +103,7 @@ fn shutdown(st: &SystemTable) -> ! {
     use uefi::table::runtime::ResetType;
 
     // Get our text output back.
-    st.stdout().reset(false).unwrap().unwrap();
+    st.stdout().reset(false).warn_unwrap();
 
     // Inform the user, and give him time to read on real hardware
     if cfg!(not(feature = "qemu")) {

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -25,7 +25,7 @@ pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable
     // Reset the console before running all the other tests.
     st.stdout()
         .reset(false)
-        .warn_expect("Failed to reset stdout");
+        .expect_success("Failed to reset stdout");
 
     // Ensure the tests are run on a version of UEFI we support.
     check_revision(st.uefi_revision());
@@ -74,23 +74,23 @@ fn check_screenshot(bt: &BootServices, name: &str) {
         io_mode.timeout = 3_000_000;
         serial
             .set_attributes(&io_mode)
-            .warn_expect("Failed to configure serial port timeout");
+            .expect_success("Failed to configure serial port timeout");
 
         // Send a screenshot request to the host
         serial
             .write(b"SCREENSHOT: ")
-            .warn_expect("Failed to send request");
+            .expect_success("Failed to send request");
         let name_bytes = name.as_bytes();
         serial
             .write(name_bytes)
-            .warn_expect("Failed to send request");
-        serial.write(b"\n").warn_expect("Failed to send request");
+            .expect_success("Failed to send request");
+        serial.write(b"\n").expect_success("Failed to send request");
 
         // Wait for the host's acknowledgement before moving forward
         let mut reply = [0; 3];
         serial
             .read(&mut reply[..])
-            .warn_expect("Failed to read host reply");
+            .expect_success("Failed to read host reply");
 
         assert_eq!(&reply[..], b"OK\n", "Unexpected screenshot request reply");
     } else {
@@ -103,7 +103,7 @@ fn shutdown(st: &SystemTable) -> ! {
     use uefi::table::runtime::ResetType;
 
     // Get our text output back.
-    st.stdout().reset(false).warn_unwrap();
+    st.stdout().reset(false).unwrap_success();
 
     // Inform the user, and give him time to read on real hardware
     if cfg!(not(feature = "qemu")) {

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -1,4 +1,5 @@
 use core::ptr;
+use uefi::prelude::*;
 use uefi::proto::console::gop::{BltOp, BltPixel, GraphicsOutput, PixelFormat};
 use uefi::table::boot::BootServices;
 use uefi_exts::BootServicesExt;
@@ -32,8 +33,7 @@ fn set_graphics_mode(gop: &mut GraphicsOutput) {
         .unwrap();
 
     gop.set_mode(&mode)
-        .expect("Failed to set graphics mode")
-        .expect("Warnings encountered while setting graphics mode");
+        .warn_expect("Failed to set graphics mode");
 }
 
 // Fill the screen with color.
@@ -45,9 +45,7 @@ fn fill_color(gop: &mut GraphicsOutput) {
         dims: (1024, 768),
     };
 
-    gop.blt(op)
-        .expect("Failed to fill screen with color")
-        .expect("Warnings encountered while filling screen with color");
+    gop.blt(op).warn_expect("Failed to fill screen with color");
 }
 
 // Draw directly to the frame buffer.

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -33,7 +33,7 @@ fn set_graphics_mode(gop: &mut GraphicsOutput) {
         .unwrap();
 
     gop.set_mode(&mode)
-        .warn_expect("Failed to set graphics mode");
+        .expect_success("Failed to set graphics mode");
 }
 
 // Fill the screen with color.
@@ -45,7 +45,8 @@ fn fill_color(gop: &mut GraphicsOutput) {
         dims: (1024, 768),
     };
 
-    gop.blt(op).warn_expect("Failed to fill screen with color");
+    gop.blt(op)
+        .expect_success("Failed to fill screen with color");
 }
 
 // Draw directly to the frame buffer.

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -24,14 +24,16 @@ fn set_graphics_mode(gop: &mut GraphicsOutput) {
     // We know for sure QEMU has a 1024x768, mode.
     let mode = gop
         .modes()
+        .map(|mode| mode.expect("Warnings encountered while querying mode"))
         .find(|ref mode| {
             let info = mode.info();
-
             info.resolution() == (1024, 768)
         })
         .unwrap();
 
-    gop.set_mode(&mode).expect("Failed to set graphics mode");
+    gop.set_mode(&mode)
+        .expect("Failed to set graphics mode")
+        .expect("Warnings encountered while setting graphics mode");
 }
 
 // Fill the screen with color.
@@ -43,7 +45,9 @@ fn fill_color(gop: &mut GraphicsOutput) {
         dims: (1024, 768),
     };
 
-    gop.blt(op).expect("Failed to fill screen with color");
+    gop.blt(op)
+        .expect("Failed to fill screen with color")
+        .expect("Warnings encountered while filling screen with color");
 }
 
 // Draw directly to the frame buffer.

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -10,11 +10,13 @@ pub fn test(bt: &BootServices) {
 
         pointer
             .reset(false)
-            .expect("Failed to reset pointer device");
+            .expect("Failed to reset pointer device")
+            .expect("Warnings encountered while resetting pointer device");
 
         let state = pointer
             .read_state()
-            .expect("Failed to retrieve pointer state");
+            .expect("Failed to retrieve pointer state")
+            .expect("Warnings encountered while retrieving pointer state");
         if let Some(state) = state {
             info!("New pointer State: {:#?}", state);
         } else {

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -1,3 +1,4 @@
+use uefi::prelude::*;
 use uefi::proto::console::pointer::Pointer;
 use uefi::table::boot::BootServices;
 
@@ -10,13 +11,12 @@ pub fn test(bt: &BootServices) {
 
         pointer
             .reset(false)
-            .expect("Failed to reset pointer device")
-            .expect("Warnings encountered while resetting pointer device");
+            .warn_expect("Failed to reset pointer device");
 
         let state = pointer
             .read_state()
-            .expect("Failed to retrieve pointer state")
-            .expect("Warnings encountered while retrieving pointer state");
+            .warn_expect("Failed to retrieve pointer state");
+
         if let Some(state) = state {
             info!("New pointer State: {:#?}", state);
         } else {

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -11,11 +11,11 @@ pub fn test(bt: &BootServices) {
 
         pointer
             .reset(false)
-            .warn_expect("Failed to reset pointer device");
+            .expect_success("Failed to reset pointer device");
 
         let state = pointer
             .read_state()
-            .warn_expect("Failed to retrieve pointer state");
+            .expect_success("Failed to retrieve pointer state");
 
         if let Some(state) = state {
             info!("New pointer State: {:#?}", state);

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -1,3 +1,4 @@
+use uefi::prelude::*;
 use uefi::proto::console::serial::{ControlBits, Serial};
 use uefi::table::boot::BootServices;
 use uefi_exts::BootServicesExt;
@@ -9,8 +10,7 @@ pub fn test(bt: &BootServices) {
 
         let old_ctrl_bits = serial
             .get_control_bits()
-            .expect("Failed to get device control bits")
-            .expect("Warnings encountered while getting device control bits");
+            .warn_expect("Failed to get device control bits");
         let mut ctrl_bits = ControlBits::empty();
 
         // For the purposes of testing, we're _not_ going to implement
@@ -22,8 +22,7 @@ pub fn test(bt: &BootServices) {
 
         serial
             .set_control_bits(ctrl_bits)
-            .expect("Failed to set device control bits")
-            .expect("Warnings encountered while setting device control bits");
+            .warn_expect("Failed to set device control bits");
 
         // Keep this message short, we need it to fit in the FIFO.
         const OUTPUT: &[u8] = b"Hello world!";
@@ -31,15 +30,13 @@ pub fn test(bt: &BootServices) {
 
         let len = serial
             .write(OUTPUT)
-            .expect("Failed to write to serial port")
-            .expect("Warnings encountered while writing to serial port");
+            .warn_expect("Failed to write to serial port");
         assert_eq!(len, MSG_LEN, "Bad serial port write length");
 
         let mut input = [0u8; MSG_LEN];
         let len = serial
             .read(&mut input)
-            .expect("Failed to read from serial port")
-            .expect("Warnings encountered while reading from serial port");
+            .warn_expect("Failed to read from serial port");
         assert_eq!(len, MSG_LEN, "Bad serial port read length");
 
         assert_eq!(&OUTPUT[..], &input[..MSG_LEN]);
@@ -47,12 +44,10 @@ pub fn test(bt: &BootServices) {
         // Clean up after ourselves
         serial
             .reset()
-            .expect("Could not reset the serial device")
-            .expect("Warnings encountered while resetting serial device");
+            .warn_expect("Could not reset the serial device");
         serial
             .set_control_bits(old_ctrl_bits & ControlBits::SETTABLE)
-            .expect("Could not restore the serial device state")
-            .expect("Warnings encountered while restoring serial device state");
+            .warn_expect("Could not restore the serial device state");
     } else {
         warn!("No serial device found");
     }

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -10,7 +10,7 @@ pub fn test(bt: &BootServices) {
 
         let old_ctrl_bits = serial
             .get_control_bits()
-            .warn_expect("Failed to get device control bits");
+            .expect_success("Failed to get device control bits");
         let mut ctrl_bits = ControlBits::empty();
 
         // For the purposes of testing, we're _not_ going to implement
@@ -22,7 +22,7 @@ pub fn test(bt: &BootServices) {
 
         serial
             .set_control_bits(ctrl_bits)
-            .warn_expect("Failed to set device control bits");
+            .expect_success("Failed to set device control bits");
 
         // Keep this message short, we need it to fit in the FIFO.
         const OUTPUT: &[u8] = b"Hello world!";
@@ -30,13 +30,13 @@ pub fn test(bt: &BootServices) {
 
         let len = serial
             .write(OUTPUT)
-            .warn_expect("Failed to write to serial port");
+            .expect_success("Failed to write to serial port");
         assert_eq!(len, MSG_LEN, "Bad serial port write length");
 
         let mut input = [0u8; MSG_LEN];
         let len = serial
             .read(&mut input)
-            .warn_expect("Failed to read from serial port");
+            .expect_success("Failed to read from serial port");
         assert_eq!(len, MSG_LEN, "Bad serial port read length");
 
         assert_eq!(&OUTPUT[..], &input[..MSG_LEN]);
@@ -44,10 +44,10 @@ pub fn test(bt: &BootServices) {
         // Clean up after ourselves
         serial
             .reset()
-            .warn_expect("Could not reset the serial device");
+            .expect_success("Could not reset the serial device");
         serial
             .set_control_bits(old_ctrl_bits & ControlBits::SETTABLE)
-            .warn_expect("Could not restore the serial device state");
+            .expect_success("Could not restore the serial device state");
     } else {
         warn!("No serial device found");
     }

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -9,7 +9,8 @@ pub fn test(bt: &BootServices) {
 
         let old_ctrl_bits = serial
             .get_control_bits()
-            .expect("Failed to get device control bits");
+            .expect("Failed to get device control bits")
+            .expect("Warnings encountered while getting device control bits");
         let mut ctrl_bits = ControlBits::empty();
 
         // For the purposes of testing, we're _not_ going to implement
@@ -21,30 +22,37 @@ pub fn test(bt: &BootServices) {
 
         serial
             .set_control_bits(ctrl_bits)
-            .expect("Failed to set device control bits");
+            .expect("Failed to set device control bits")
+            .expect("Warnings encountered while setting device control bits");
 
         // Keep this message short, we need it to fit in the FIFO.
-        let output = b"Hello world!";
-        let msg_len = output.len();
+        const OUTPUT: &[u8] = b"Hello world!";
+        const MSG_LEN: usize = OUTPUT.len();
 
         let len = serial
-            .write(output)
-            .expect("Failed to write to serial port");
-        assert_eq!(len, msg_len, "Serial port write timed-out!");
+            .write(OUTPUT)
+            .expect("Failed to write to serial port")
+            .expect("Warnings encountered while writing to serial port");
+        assert_eq!(len, MSG_LEN, "Bad serial port write length");
 
-        let mut input = [0u8; 128];
+        let mut input = [0u8; MSG_LEN];
         let len = serial
             .read(&mut input)
-            .expect("Failed to read from serial port");
-        assert_eq!(len, msg_len, "Serial port read timed-out!");
+            .expect("Failed to read from serial port")
+            .expect("Warnings encountered while reading from serial port");
+        assert_eq!(len, MSG_LEN, "Bad serial port read length");
 
-        assert_eq!(&output[..], &input[..msg_len]);
+        assert_eq!(&OUTPUT[..], &input[..MSG_LEN]);
 
         // Clean up after ourselves
-        serial.reset().expect("Could not reset the serial device");
+        serial
+            .reset()
+            .expect("Could not reset the serial device")
+            .expect("Warnings encountered while resetting serial device");
         serial
             .set_control_bits(old_ctrl_bits & ControlBits::SETTABLE)
-            .expect("Could not restore the serial device state");
+            .expect("Could not restore the serial device state")
+            .expect("Warnings encountered while restoring serial device state");
     } else {
         warn!("No serial device found");
     }

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -10,8 +10,9 @@ pub fn test(stdout: &mut Output) {
 
     // Print all modes.
     for (index, mode) in stdout.modes().enumerate() {
+        let mode = mode.expect("Warnings encountered while querying text mode");
         info!(
-            "- Graphics mode #{}: {} rows by {} columns",
+            "- Text mode #{}: {} rows by {} columns",
             index,
             mode.rows(),
             mode.columns()
@@ -19,39 +20,61 @@ pub fn test(stdout: &mut Output) {
     }
 
     // Should clean up after us.
-    stdout.reset(false).unwrap();
+    stdout.reset(false).unwrap().unwrap();
 }
 
-// Switch to the maximum supported graphics mode.
+// Switch to the maximum supported text mode.
 fn change_text_mode(stdout: &mut Output) {
-    let best_mode = stdout.modes().last().unwrap();
+    let best_mode = stdout
+        .modes()
+        .last()
+        .unwrap()
+        .expect("Warnings encountered while querying text mode");;
     stdout
         .set_mode(best_mode)
-        .expect("Failed to change graphics mode");
+        .expect("Failed to change text mode")
+        .expect("Warnings encountered while changing text mode");
 }
 
 // Set a new color, and paint the background with it.
 fn change_color(stdout: &mut Output) {
     stdout
         .set_color(Color::White, Color::Blue)
-        .expect("Failed to change console color");
-    stdout.clear().expect("Failed to clear screen");
+        .expect("Failed to change console color")
+        .expect("Warnings encountered while changing console color");
+    stdout
+        .clear()
+        .expect("Failed to clear screen")
+        .expect("Warnings encountered while clearing screen");
 }
 
 // Print a text centered on screen.
 fn center_text(stdout: &mut Output) {
     // Move the cursor.
     // This will make this `info!` line below be (somewhat) centered.
-    stdout.enable_cursor(true).unwrap_or_else(|s| match s {
-        Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
-        _ => panic!("Failed to show cursor"),
-    });
+    stdout
+        .enable_cursor(true)
+        .unwrap_or_else(|s| {
+            match s {
+                Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
+                _ => panic!("Failed to show cursor"),
+            }
+            .into()
+        })
+        .expect("Warnings encountered while enabling cursor");
     stdout
         .set_cursor_position(24, 0)
-        .expect("Failed to move cursor");
+        .expect("Failed to move cursor")
+        .expect("Warnings encountered while moving cursor");
     info!("# uefi-rs test runner");
-    stdout.enable_cursor(false).unwrap_or_else(|s| match s {
-        Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
-        _ => panic!("Failed to hide cursor"),
-    });
+    stdout
+        .enable_cursor(false)
+        .unwrap_or_else(|s| {
+            match s {
+                Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
+                _ => panic!("Failed to hide cursor"),
+            }
+            .into()
+        })
+        .expect("Warnings encountered while enabling cursor");
 }

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -20,7 +20,7 @@ pub fn test(stdout: &mut Output) {
     }
 
     // Should clean up after us.
-    stdout.reset(false).unwrap().unwrap();
+    stdout.reset(false).warn_unwrap();
 }
 
 // Switch to the maximum supported text mode.
@@ -29,23 +29,18 @@ fn change_text_mode(stdout: &mut Output) {
         .modes()
         .last()
         .unwrap()
-        .expect("Warnings encountered while querying text mode");;
+        .expect("Warnings encountered while querying text mode");
     stdout
         .set_mode(best_mode)
-        .expect("Failed to change text mode")
-        .expect("Warnings encountered while changing text mode");
+        .warn_expect("Failed to change text mode");
 }
 
 // Set a new color, and paint the background with it.
 fn change_color(stdout: &mut Output) {
     stdout
         .set_color(Color::White, Color::Blue)
-        .expect("Failed to change console color")
-        .expect("Warnings encountered while changing console color");
-    stdout
-        .clear()
-        .expect("Failed to clear screen")
-        .expect("Warnings encountered while clearing screen");
+        .warn_expect("Failed to change console color");
+    stdout.clear().warn_expect("Failed to clear screen");
 }
 
 // Print a text centered on screen.
@@ -54,27 +49,20 @@ fn center_text(stdout: &mut Output) {
     // This will make this `info!` line below be (somewhat) centered.
     stdout
         .enable_cursor(true)
-        .unwrap_or_else(|s| {
-            match s {
-                Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
-                _ => panic!("Failed to show cursor"),
-            }
-            .into()
-        })
-        .expect("Warnings encountered while enabling cursor");
+        .warn_err()
+        .unwrap_or_else(|s| match s {
+            Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
+            _ => panic!("Failed to show cursor"),
+        });
     stdout
         .set_cursor_position(24, 0)
-        .expect("Failed to move cursor")
-        .expect("Warnings encountered while moving cursor");
+        .warn_expect("Failed to move cursor");
     info!("# uefi-rs test runner");
     stdout
         .enable_cursor(false)
-        .unwrap_or_else(|s| {
-            match s {
-                Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
-                _ => panic!("Failed to hide cursor"),
-            }
-            .into()
-        })
-        .expect("Warnings encountered while enabling cursor");
+        .warn_err()
+        .unwrap_or_else(|s| match s {
+            Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
+            _ => panic!("Failed to hide cursor"),
+        });
 }

--- a/uefi-test-runner/src/proto/console/stdout.rs
+++ b/uefi-test-runner/src/proto/console/stdout.rs
@@ -20,7 +20,7 @@ pub fn test(stdout: &mut Output) {
     }
 
     // Should clean up after us.
-    stdout.reset(false).warn_unwrap();
+    stdout.reset(false).unwrap_success();
 }
 
 // Switch to the maximum supported text mode.
@@ -32,15 +32,15 @@ fn change_text_mode(stdout: &mut Output) {
         .expect("Warnings encountered while querying text mode");
     stdout
         .set_mode(best_mode)
-        .warn_expect("Failed to change text mode");
+        .expect_success("Failed to change text mode");
 }
 
 // Set a new color, and paint the background with it.
 fn change_color(stdout: &mut Output) {
     stdout
         .set_color(Color::White, Color::Blue)
-        .warn_expect("Failed to change console color");
-    stdout.clear().warn_expect("Failed to clear screen");
+        .expect_success("Failed to change console color");
+    stdout.clear().expect_success("Failed to clear screen");
 }
 
 // Print a text centered on screen.
@@ -49,18 +49,18 @@ fn center_text(stdout: &mut Output) {
     // This will make this `info!` line below be (somewhat) centered.
     stdout
         .enable_cursor(true)
-        .warn_err()
+        .warning_as_error()
         .unwrap_or_else(|s| match s {
             Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
             _ => panic!("Failed to show cursor"),
         });
     stdout
         .set_cursor_position(24, 0)
-        .warn_expect("Failed to move cursor");
+        .expect_success("Failed to move cursor");
     info!("# uefi-rs test runner");
     stdout
         .enable_cursor(false)
-        .warn_err()
+        .warning_as_error()
         .unwrap_or_else(|s| match s {
             Status::UNSUPPORTED => info!("Cursor visibility control unavailable"),
             _ => panic!("Failed to hide cursor"),

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -19,7 +19,8 @@ fn find_protocol(bt: &BootServices) {
 
     let handles = bt
         .find_handles::<SearchedProtocol>()
-        .expect("Failed to retrieve list of handles");
+        .expect("Failed to retrieve list of handles")
+        .expect("Warnings encountered while retrieving list of handles");
     assert!(
         handles.len() > 1,
         "There should be at least one implementation of Simple Text Output (stdout)"

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -19,8 +19,7 @@ fn find_protocol(bt: &BootServices) {
 
     let handles = bt
         .find_handles::<SearchedProtocol>()
-        .expect("Failed to retrieve list of handles")
-        .expect("Warnings encountered while retrieving list of handles");
+        .warn_expect("Failed to retrieve list of handles");
     assert!(
         handles.len() > 1,
         "There should be at least one implementation of Simple Text Output (stdout)"

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -19,7 +19,8 @@ fn find_protocol(bt: &BootServices) {
 
     let handles = bt
         .find_handles::<SearchedProtocol>()
-        .warn_expect("Failed to retrieve list of handles");
+        .expect_success("Failed to retrieve list of handles");
+
     assert!(
         handles.len() > 1,
         "There should be at least one implementation of Simple Text Output (stdout)"


### PR DESCRIPTION
UEFI has warnings, which represent non-fatal errors. Currently, we treat them as fatal errors, which is somewhat pessimistic. This PR explores a different strategy which allows the user to do various things with warnings including pattern-matching them, logging them silently, or handling them as errors.

Some errors which were previously discarded, such as `EFI_TIMEOUT` in serial communication, are now reported as warnings.

Fixes #52.