### PR TITLE
Type-safety cleanup and safe exit from boot services

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ The following steps allow you to build a simple UEFI app.
 
 ```rust
 #[no_mangle]
-pub extern "win64" fn uefi_start(handle: Handle, system_table: &'static table::SystemTable) -> Status;
+pub extern "win64" fn uefi_start(handle: Handle, system_table: BootSystemTable) -> Status;
 ```
 
 - Copy the `uefi-test-runner/x86_64-uefi.json` target file to your project's root.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ The following steps allow you to build a simple UEFI app.
 
 ```rust
 #[no_mangle]
-pub extern "win64" fn uefi_start(handle: Handle, system_table: BootSystemTable) -> Status;
+pub extern "win64" fn uefi_start(handle: Handle, system_table: SystemTable<Boot>) -> Status;
 ```
 
 - Copy the `uefi-test-runner/x86_64-uefi.json` target file to your project's root.

--- a/src/error/completion.rs
+++ b/src/error/completion.rs
@@ -52,7 +52,7 @@ impl<T> Completion<T> {
     }
 
     /// Transform the inner value without unwrapping the Completion
-    pub fn map<U>(self, f: impl Fn(T) -> U) -> Completion<U> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Completion<U> {
         match self {
             Completion::Success(res) => Completion::Success(f(res)),
             Completion::Warning(res, stat) => Completion::Warning(f(res), stat),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -25,7 +25,7 @@ pub trait ResultExt<T> {
     fn expect_success(self, msg: &str) -> T;
 
     /// Transform the inner output, if any
-    fn map_inner<U>(self, f: impl Fn(T) -> U) -> Result<U>;
+    fn map_inner<U>(self, f: impl FnOnce(T) -> U) -> Result<U>;
 }
 
 impl<T> ResultExt<T> for Result<T> {
@@ -49,7 +49,7 @@ impl<T> ResultExt<T> for Result<T> {
         self.expect(msg).expect(msg)
     }
 
-    fn map_inner<U>(self, f: impl Fn(T) -> U) -> Result<U> {
+    fn map_inner<U>(self, f: impl FnOnce(T) -> U) -> Result<U> {
         self.map(|completion| completion.map(f))
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,4 +5,6 @@
 pub use crate::{ResultExt, Status};
 
 // Import the basic table types.
-pub use crate::table::{boot::BootServices, runtime::RuntimeServices, BootSystemTable};
+pub use crate::table::boot::BootServices;
+pub use crate::table::runtime::RuntimeServices;
+pub use crate::table::{Boot, SystemTable};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,4 +5,4 @@
 pub use crate::{ResultExt, Status};
 
 // Import the basic table types.
-pub use crate::table::{boot::BootServices, runtime::RuntimeServices, SystemTable};
+pub use crate::table::{boot::BootServices, runtime::RuntimeServices, BootSystemTable};

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -63,7 +63,7 @@ impl GraphicsOutput {
         let mut info = ptr::null();
 
         (self.query_mode)(self, index, &mut info_sz, &mut info).into_with(|| {
-            let info = unsafe { &*info };
+            let info = unsafe { *info };
             Mode {
                 index,
                 info_sz,
@@ -203,7 +203,16 @@ impl GraphicsOutput {
                 self.check_framebuffer_region((src_x, src_y), (width, height));
                 self.check_framebuffer_region((dest_x, dest_y), (width, height));
                 (self.blt)(
-                    self, ptr::null_mut(), 3, src_x, src_y, dest_x, dest_y, width, height, 0,
+                    self,
+                    ptr::null_mut(),
+                    3,
+                    src_x,
+                    src_y,
+                    dest_x,
+                    dest_y,
+                    width,
+                    height,
+                    0,
                 )
                 .into()
             }
@@ -329,7 +338,7 @@ pub struct PixelBitmask {
 pub struct Mode {
     index: u32,
     info_sz: usize,
-    info: &'static ModeInfo,
+    info: ModeInfo,
 }
 
 impl Mode {
@@ -342,7 +351,7 @@ impl Mode {
 
     /// Returns a reference to the mode info structure.
     pub fn info(&self) -> &ModeInfo {
-        self.info
+        &self.info
     }
 }
 

--- a/src/proto/console/gop.rs
+++ b/src/proto/console/gop.rs
@@ -33,7 +33,7 @@ use crate::{Completion, Result, Status};
 /// The GOP can be used to set the properties of the frame buffer,
 /// and also allows the app to access the in-memory buffer.
 #[repr(C)]
-pub struct GraphicsOutput {
+pub struct GraphicsOutput<'boot> {
     query_mode:
         extern "win64" fn(&GraphicsOutput, mode: u32, info_sz: &mut usize, &mut *const ModeInfo)
             -> Status,
@@ -52,10 +52,10 @@ pub struct GraphicsOutput {
         height: usize,
         stride: usize,
     ) -> Status,
-    mode: &'static ModeData<'static>,
+    mode: &'boot ModeData<'boot>,
 }
 
-impl GraphicsOutput {
+impl<'boot> GraphicsOutput<'boot> {
     /// Returns information for an available graphics mode that the graphics
     /// device and the set of active video output devices supports.
     fn query_mode(&self, index: u32) -> Result<Mode> {
@@ -278,7 +278,7 @@ impl GraphicsOutput {
 }
 
 impl_proto! {
-    protocol GraphicsOutput {
+    protocol GraphicsOutput<'boot> {
         GUID = 0x9042a9de, 0x23dc, 0x4a38, [0x96, 0xfb, 0x7a, 0xde, 0xd0, 0x80, 0x51, 0x6a];
     }
 }
@@ -400,7 +400,7 @@ impl ModeInfo {
 
 /// Iterator for graphics modes.
 struct ModeIter<'a> {
-    gop: &'a GraphicsOutput,
+    gop: &'a GraphicsOutput<'a>,
     current: u32,
     max: u32,
 }

--- a/src/proto/console/pointer/mod.rs
+++ b/src/proto/console/pointer/mod.rs
@@ -5,14 +5,14 @@ use crate::{Event, Result, Status};
 
 /// Provides information about a pointer device.
 #[repr(C)]
-pub struct Pointer {
+pub struct Pointer<'boot> {
     reset: extern "win64" fn(this: &mut Pointer, ext_verif: bool) -> Status,
     get_state: extern "win64" fn(this: &Pointer, state: &mut PointerState) -> Status,
     wait_for_input: Event,
-    mode: &'static PointerMode,
+    mode: &'boot PointerMode,
 }
 
-impl Pointer {
+impl<'boot> Pointer<'boot> {
     /// Resets the pointer device hardware.
     ///
     /// The `extended_verification` parameter is used to request that UEFI
@@ -55,7 +55,7 @@ impl Pointer {
 }
 
 impl_proto! {
-    protocol Pointer {
+    protocol Pointer<'boot> {
         GUID = 0x31878c87, 0xb75, 0x11d5, [0x9a, 0x4f, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d];
     }
 }

--- a/src/proto/console/serial.rs
+++ b/src/proto/console/serial.rs
@@ -11,7 +11,7 @@ use crate::{Completion, Result, Status};
 /// Since UEFI drivers are implemented through polling, if you fail to regularly
 /// check for input/output, some data might be lost.
 #[repr(C)]
-pub struct Serial {
+pub struct Serial<'boot> {
     // Revision of this protocol, only 1.0 is currently defined.
     // Future versions will be backwards compatible.
     revision: u32,
@@ -29,10 +29,10 @@ pub struct Serial {
     get_control_bits: extern "win64" fn(&Serial, &mut ControlBits) -> Status,
     write: extern "win64" fn(&mut Serial, &mut usize, *const u8) -> Status,
     read: extern "win64" fn(&mut Serial, &mut usize, *mut u8) -> Status,
-    io_mode: &'static IoMode,
+    io_mode: &'boot IoMode,
 }
 
-impl Serial {
+impl<'boot> Serial<'boot> {
     /// Reset the device.
     pub fn reset(&mut self) -> Result<()> {
         (self.reset)(self).into()
@@ -117,7 +117,7 @@ impl Serial {
 }
 
 impl_proto! {
-    protocol Serial {
+    protocol Serial<'boot> {
         GUID = 0xBB25CF6F, 0xF1D4, 0x11D2, [0x9A, 0x0C, 0x00, 0x90, 0x27, 0x3F, 0xC1, 0xFD];
     }
 }

--- a/src/proto/macros.rs
+++ b/src/proto/macros.rs
@@ -33,4 +33,21 @@ macro_rules! impl_proto {
         // Most UEFI functions do not support multithreaded access.
         impl !Sync for $p {}
     };
+    (
+        protocol $p:ident<'boot> {
+            GUID = $a:expr, $b:expr, $c:expr, $d:expr;
+        }
+    ) => {
+        impl<'boot> $crate::proto::Protocol for $p<'boot> {
+            #[doc(hidden)]
+            // These literals aren't meant to be human-readable.
+            #[allow(clippy::unreadable_literal)]
+            const GUID: $crate::Guid = $crate::Guid::from_values($a, $b, $c, $d);
+        }
+
+        // Most UEFI functions expect to be called on the bootstrap processor.
+        impl<'boot> !Send for $p<'boot> {}
+        // Most UEFI functions do not support multithreaded access.
+        impl<'boot> !Sync for $p<'boot> {}
+    };
 }

--- a/src/proto/media/fs.rs
+++ b/src/proto/media/fs.rs
@@ -1,8 +1,8 @@
 //! File system support protocols.
 
+use super::file::{File, FileImpl};
 use core::ptr;
 use crate::{Result, Status};
-use super::file::{File, FileImpl};
 
 /// Allows access to a FAT-12/16/32 file system.
 ///

--- a/src/proto/media/fs.rs
+++ b/src/proto/media/fs.rs
@@ -1,8 +1,8 @@
 //! File system support protocols.
 
+use core::ptr;
 use crate::{Result, Status};
-
-use super::file::File;
+use super::file::{File, FileImpl};
 
 /// Allows access to a FAT-12/16/32 file system.
 ///
@@ -11,7 +11,7 @@ use super::file::File;
 #[repr(C)]
 pub struct SimpleFileSystem {
     revision: u64,
-    open_volume: extern "win64" fn(this: &mut SimpleFileSystem, root: &mut usize) -> Status,
+    open_volume: extern "win64" fn(this: &mut SimpleFileSystem, root: &mut *mut FileImpl) -> Status,
 }
 
 impl SimpleFileSystem {
@@ -26,7 +26,7 @@ impl SimpleFileSystem {
     /// * `uefi::Status::OUT_OF_RESOURCES` - The volume was not opened
     /// * `uefi::Status::MEDIA_CHANGED` - The device has a different medium in it
     pub fn open_volume(&mut self) -> Result<File> {
-        let mut ptr = 0usize;
+        let mut ptr = ptr::null_mut();
         (self.open_volume)(self, &mut ptr).into_with(|| unsafe { File::new(ptr) })
     }
 }

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -354,13 +354,13 @@ impl BootServices {
     /// Exits the UEFI boot services
     ///
     /// This unsafe method is meant to be an implementation detail of the safe
-    /// `BootSystemTable::exit_boot_services()` method, which is why it is not
+    /// `SystemTable<Boot>::exit_boot_services()` method, which is why it is not
     /// public.
     ///
     /// Everything that is explained in the documentation of the high-level
-    /// BootSystemTable is also true here, except that this function is one-shot
-    /// (no automatic retry) and does not prevent you from shooting yourself in
-    /// the foot by calling invalid boot services after a failure.
+    /// SystemTable<Boot> method is also true here, except that this function is
+    /// one-shot (no automatic retry) and does not prevent you from shooting
+    /// yourself in the foot by calling invalid boot services after a failure.
     pub(super) unsafe fn exit_boot_services(
         &self,
         image: Handle,

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -361,7 +361,11 @@ impl BootServices {
     /// BootSystemTable is also true here, except that this function is one-shot
     /// (no automatic retry) and does not prevent you from shooting yourself in
     /// the foot by calling invalid boot services after a failure.
-    pub(super) unsafe fn exit_boot_services(&self, image: Handle, mmap_key: MemoryMapKey) -> Result<()> {
+    pub(super) unsafe fn exit_boot_services(
+        &self,
+        image: Handle,
+        mmap_key: MemoryMapKey,
+    ) -> Result<()> {
         (self.exit_boot_services)(image, mmap_key).into()
     }
 
@@ -648,31 +652,31 @@ bitflags! {
     pub struct EventType: u32 {
         /// The event is a timer event and may be passed to `BootServices::set_timer()`
         /// Note that timers only function during boot services time.
-        const TIMER = 0x80000000;
+        const TIMER = 0x8000_0000;
 
         /// The event is allocated from runtime memory.
         /// This must be done if the event is to be signaled after ExitBootServices.
-        const RUNTIME = 0x40000000;
+        const RUNTIME = 0x4000_0000;
 
         /// Calling wait_for_event or check_event will enqueue the notification
         /// function if the event is not already in the signaled state.
         /// Mutually exclusive with NOTIFY_SIGNAL.
-        const NOTIFY_WAIT = 0x00000100;
+        const NOTIFY_WAIT = 0x0000_0100;
 
         /// The notification function will be enqueued when the event is signaled
         /// Mutually exclusive with NOTIFY_WAIT.
-        const NOTIFY_SIGNAL = 0x00000200;
+        const NOTIFY_SIGNAL = 0x0000_0200;
 
         /// The event will be signaled at ExitBootServices time.
         /// This event type should not be combined with any other.
         /// Its notification function must follow some special rules:
         /// - Cannot use memory allocation services, directly or indirectly
         /// - Cannot depend on timer events, since those will be deactivated
-        const SIGNAL_EXIT_BOOT_SERVICES = 0x00000201;
+        const SIGNAL_EXIT_BOOT_SERVICES = 0x0000_0201;
 
         /// The event will be notified when SetVirtualAddressMap is performed.
         /// This event type should not be combined with any other.
-        const SIGNAL_VIRTUAL_ADDRESS_CHANGE = 0x60000202;
+        const SIGNAL_VIRTUAL_ADDRESS_CHANGE = 0x6000_0202;
     }
 }
 

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -612,7 +612,7 @@ impl<'a> Iterator for MemoryMapIter<'a> {
 
             self.index += 1;
 
-            let descriptor = unsafe { mem::transmute::<usize, &MemoryDescriptor>(ptr) };
+            let descriptor: &MemoryDescriptor = unsafe { mem::transmute(ptr) };
 
             Some(descriptor)
         } else {

--- a/src/table/boot.rs
+++ b/src/table/boot.rs
@@ -118,7 +118,9 @@ impl BootServices {
 
     /// Allocates memory pages from the system.
     ///
-    /// UEFI OS loaders should allocate memory of the type `LoaderData`.
+    /// UEFI OS loaders should allocate memory of the type `LoaderData`. An u64
+    /// is returned even on 32-bit platforms because some hardware configurations
+    /// like Intel PAE enable 64-bit physical addressing on a 32-bit processor.
     pub fn allocate_pages(
         &self,
         ty: AllocateType,
@@ -200,7 +202,7 @@ impl BootServices {
         })
     }
 
-    /// Allocates from a memory pool. The address is 8-byte aligned.
+    /// Allocates from a memory pool. The pointer will be 8-byte aligned.
     pub fn allocate_pool(&self, mem_ty: MemoryType, size: usize) -> Result<*mut u8> {
         let mut buffer = ptr::null_mut();
         (self.allocate_pool)(mem_ty, size, &mut buffer).into_with(|| buffer)

--- a/src/table/cfg.rs
+++ b/src/table/cfg.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::unreadable_literal)]
 
 use bitflags::bitflags;
+use core::ffi::c_void;
 use crate::Guid;
 
 /// Contains a set of GUID / pointer for a vendor-specific table.
@@ -23,7 +24,7 @@ pub struct ConfigTableEntry {
     /// The starting address of this table.
     ///
     /// Whether this is a physical or virtual address depends on the table.
-    pub address: usize,
+    pub address: *const c_void,
 }
 
 /// Entry pointing to the old ACPI 1 RSDP.

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -14,7 +14,7 @@ mod revision;
 pub use self::revision::Revision;
 
 mod system;
-pub use self::system::SystemTable;
+pub use self::system::BootSystemTable;
 
 pub mod boot;
 pub mod runtime;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -14,7 +14,7 @@ mod revision;
 pub use self::revision::Revision;
 
 mod system;
-pub use self::system::BootSystemTable;
+pub use self::system::{Boot, Runtime, SystemTable};
 
 pub mod boot;
 pub mod runtime;

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -1,6 +1,6 @@
-use super::{cfg, Header, Revision};
 use super::boot::BootServices;
 use super::runtime::RuntimeServices;
+use super::{cfg, Header, Revision};
 use core::slice;
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle};

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -24,7 +24,7 @@ pub struct SystemTable {
     /// Number of entires in the configuration table.
     nr_cfg: usize,
     /// Pointer to beginning of the array.
-    cfg_table: *mut cfg::ConfigTableEntry,
+    cfg_table: *const cfg::ConfigTableEntry,
 }
 
 // This is unsafe, but it's the best solution we have from now.

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -1,4 +1,6 @@
 use super::{cfg, Header, Revision};
+use super::boot::BootServices;
+use super::runtime::RuntimeServices;
 use core::slice;
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle};
@@ -18,9 +20,9 @@ pub struct SystemTable {
     stderr_handle: Handle,
     stderr: *mut text::Output,
     /// Runtime services table.
-    pub runtime: &'static super::runtime::RuntimeServices,
+    runtime: &'static RuntimeServices,
     /// Boot services table.
-    pub boot: &'static super::boot::BootServices,
+    boot: &'static BootServices,
     /// Number of entires in the configuration table.
     nr_cfg: usize,
     /// Pointer to beginning of the array.
@@ -54,6 +56,16 @@ impl SystemTable {
     /// Returns the standard error protocol.
     pub fn stderr(&self) -> &mut text::Output {
         unsafe { &mut *self.stderr }
+    }
+
+    /// Access runtime services
+    pub fn runtime_services(&self) -> &RuntimeServices {
+        self.runtime
+    }
+
+    /// Access boot services
+    pub fn boot_services(&self) -> &BootServices {
+        self.boot
     }
 
     /// Returns the config table entries, a linear array of structures

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -159,8 +159,7 @@ impl SystemTable<Boot> {
                             table: self.table,
                             _marker: PhantomData,
                         };
-                        comp.map(|_| (st, mmap_iter))
-                            .with_status(mmap_status)
+                        comp.map(|_| (st, mmap_iter)).with_status(mmap_status)
                     });
                 }
             }

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -5,14 +5,114 @@ use core::slice;
 use crate::proto::console::text;
 use crate::{CStr16, Char16, Handle};
 
+
+/// Boot-time version of the UEFI System Table
+///
+/// This is the view of the UEFI System Table that an UEFI application is
+/// provided with initially. It enables calling all UEFI services, including
+/// so-called boot services, and exchanging information with the standard input,
+/// output and error streams.
+///
+/// Once an UEFI OS loader is ready to take over the system, it can call
+/// `exit_boot_services` to terminate the UEFI boot services. This will consume
+/// the BootSystemTable (enabling the Rust borrow checker to tell you about any
+/// boot service handle that you forgot about) and give you a RuntimeSystemTable
+/// which is more appropriate for post-boot usage.
+#[repr(transparent)]
+pub struct BootSystemTable(&'static SystemTable);
+
+// This is unsafe, but it's the best solution we have from now.
+#[allow(clippy::mut_from_ref)]
+impl BootSystemTable {
+    /// Return the firmware vendor string
+    pub fn firmware_vendor(&self) -> &CStr16 {
+        unsafe { CStr16::from_ptr(self.0.fw_vendor) }
+    }
+
+    /// Return the firmware revision
+    pub fn firmware_revision(&self) -> Revision {
+        self.0.fw_revision
+    }
+
+    /// Returns the revision of this table, which is defined to be
+    /// the revision of the UEFI specification implemented by the firmware.
+    pub fn uefi_revision(&self) -> Revision {
+        self.0.header.revision
+    }
+
+    /// Returns the standard input protocol.
+    pub fn stdin(&self) -> &mut text::Input {
+        unsafe { &mut *self.0.stdin }
+    }
+
+    /// Returns the standard output protocol.
+    pub fn stdout(&self) -> &mut text::Output {
+        let stdout_ptr = self.0.stdout as *const _ as *mut _;
+        unsafe { &mut *stdout_ptr }
+    }
+
+    /// Returns the standard error protocol.
+    pub fn stderr(&self) -> &mut text::Output {
+        let stderr_ptr = self.0.stderr as *const _ as *mut _;
+        unsafe { &mut *stderr_ptr }
+    }
+
+    /// Access runtime services
+    pub fn runtime_services(&self) -> &RuntimeServices {
+        self.0.runtime
+    }
+
+    /// Access boot services
+    pub fn boot_services(&self) -> &BootServices {
+        unsafe { &*self.0.boot }
+    }
+
+    /// Returns the config table entries, a linear array of structures
+    /// pointing to other system-specific tables.
+    pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
+        unsafe { slice::from_raw_parts(self.0.cfg_table, self.0.nr_cfg) }
+    }
+
+    // TODO: Provide a way to exit boot services and get a RuntimeSystemTable,
+    //       consuming the BootSystemTable in the process. The interface must
+    //       allow get_memory_map calls and calls to run-time services, but no
+    //       calls to boot-time services since these can be shut down after the
+    //       first attempt.
+
+    /// Clone this UEFI system table handle
+    ///
+    /// This is unsafe because you must guarantee that the clone will not be
+    /// used after boot services are exited. However, the singleton-based
+    /// designs that Rust uses for memory allocation, logging, and panic
+    /// handling require taking this risk.
+    pub unsafe fn clone(&self) -> Self {
+        BootSystemTable(self.0)
+    }
+}
+
+
+/// Run-time version of the UEFI System Table
+///
+/// This is the view of the UEFI System Table that an UEFI application has after
+/// exiting the boot services.
+///
+/// It does not expose functionality which is unavailable after exiting boot
+/// services, and actions which are very likely to become unsafe after an
+/// operating system has started initializing are marked as such.
+#[repr(transparent)]
+pub struct RuntimeSystemTable(&'static SystemTable);
+
+// TODO: Provide a RuntimeSystemTable, paying attention to what's now unsafe
+
+
 /// The system table entry points for accessing the core UEFI system functionality.
 #[repr(C)]
-pub struct SystemTable {
+struct SystemTable {
     header: Header,
     /// Null-terminated string representing the firmware's vendor.
     fw_vendor: *const Char16,
     /// Revision of the UEFI specification the firmware conforms to.
-    pub fw_revision: Revision,
+    fw_revision: Revision,
     stdin_handle: Handle,
     stdin: *mut text::Input,
     stdout_handle: Handle,
@@ -22,59 +122,11 @@ pub struct SystemTable {
     /// Runtime services table.
     runtime: &'static RuntimeServices,
     /// Boot services table.
-    boot: &'static BootServices,
+    boot: *const BootServices,
     /// Number of entires in the configuration table.
     nr_cfg: usize,
     /// Pointer to beginning of the array.
     cfg_table: *const cfg::ConfigTableEntry,
-}
-
-// This is unsafe, but it's the best solution we have from now.
-#[allow(clippy::mut_from_ref)]
-impl SystemTable {
-    /// Return the firmware vendor string
-    pub fn firmware_vendor(&self) -> &CStr16 {
-        unsafe { CStr16::from_ptr(self.fw_vendor) }
-    }
-
-    /// Returns the revision of this table, which is defined to be
-    /// the revision of the UEFI specification implemented by the firmware.
-    pub fn uefi_revision(&self) -> Revision {
-        self.header.revision
-    }
-
-    /// Returns the standard input protocol.
-    pub fn stdin(&self) -> &mut text::Input {
-        unsafe { &mut *self.stdin }
-    }
-
-    /// Returns the standard output protocol.
-    pub fn stdout(&self) -> &mut text::Output {
-        let stdout_ptr = self.stdout as *const _ as *mut _;
-        unsafe { &mut *stdout_ptr }
-    }
-
-    /// Returns the standard error protocol.
-    pub fn stderr(&self) -> &mut text::Output {
-        let stderr_ptr = self.stderr as *const _ as *mut _;
-        unsafe { &mut *stderr_ptr }
-    }
-
-    /// Access runtime services
-    pub fn runtime_services(&self) -> &RuntimeServices {
-        self.runtime
-    }
-
-    /// Access boot services
-    pub fn boot_services(&self) -> &BootServices {
-        self.boot
-    }
-
-    /// Returns the config table entries, a linear array of structures
-    /// pointing to other system-specific tables.
-    pub fn config_table(&self) -> &[cfg::ConfigTableEntry] {
-        unsafe { slice::from_raw_parts(self.cfg_table, self.nr_cfg) }
-    }
 }
 
 impl super::Table for SystemTable {

--- a/src/table/system.rs
+++ b/src/table/system.rs
@@ -16,9 +16,9 @@ pub struct SystemTable {
     stdin_handle: Handle,
     stdin: *mut text::Input,
     stdout_handle: Handle,
-    stdout: *mut text::Output,
+    stdout: *mut text::Output<'static>,
     stderr_handle: Handle,
-    stderr: *mut text::Output,
+    stderr: *mut text::Output<'static>,
     /// Runtime services table.
     runtime: &'static RuntimeServices,
     /// Boot services table.
@@ -50,12 +50,14 @@ impl SystemTable {
 
     /// Returns the standard output protocol.
     pub fn stdout(&self) -> &mut text::Output {
-        unsafe { &mut *self.stdout }
+        let stdout_ptr = self.stdout as *const _ as *mut _;
+        unsafe { &mut *stdout_ptr }
     }
 
     /// Returns the standard error protocol.
     pub fn stderr(&self) -> &mut text::Output {
-        unsafe { &mut *self.stderr }
+        let stderr_ptr = self.stderr as *const _ as *mut _;
+        unsafe { &mut *stderr_ptr }
     }
 
     /// Access runtime services

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -12,8 +12,6 @@
 #![warn(missing_docs)]
 #![deny(clippy::all)]
 #![no_std]
-// Custom allocators are currently unstable.
-#![feature(allocator_api)]
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -75,7 +75,11 @@ unsafe impl GlobalAlloc for Allocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        boot_services().as_ref().free_pool(ptr).warning_as_error().unwrap();
+        boot_services()
+            .as_ref()
+            .free_pool(ptr)
+            .warning_as_error()
+            .unwrap();
     }
 }
 

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -30,8 +30,8 @@ static mut BOOT_SERVICES: Option<NonNull<BootServices>> = None;
 
 /// Initializes the allocator.
 ///
-/// You must make sure that exit_boot_services will be called before UEFI boot
-/// services are exited.
+/// This function is unsafe because you _must_ make sure that exit_boot_services
+/// will be called when UEFI boot services will be exited.
 pub unsafe fn init(boot_services: &BootServices) {
     BOOT_SERVICES = NonNull::new(boot_services as *const _ as *mut _);
 }
@@ -43,7 +43,7 @@ fn boot_services() -> NonNull<BootServices> {
 
 /// Notify the allocator library that boot services are not safe to call anymore
 ///
-/// You should call this function before exiting UEFI boot services.
+/// You must arrange for this function to be called on exit from UEFI boot services
 pub fn exit_boot_services() {
     unsafe {
         BOOT_SERVICES = None;

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -54,14 +54,12 @@ unsafe impl GlobalAlloc for Allocator {
             boot_services()
                 .allocate_pool(mem_ty, size)
                 .warning_as_error()
-                .map(|addr| addr as *mut _)
                 .unwrap_or(ptr::null_mut())
         }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        let addr = ptr as usize;
-        boot_services().free_pool(addr).warning_as_error().unwrap();
+        boot_services().free_pool(ptr).warning_as_error().unwrap();
     }
 }
 

--- a/uefi-alloc/src/lib.rs
+++ b/uefi-alloc/src/lib.rs
@@ -7,6 +7,9 @@
 //!
 //! Call the `init` function with a reference to the boot services table.
 //! Failure to do so before calling a memory allocating function will panic.
+//!
+//! Call the `exit_boot_services` function before exiting UEFI boot services.
+//! Failure to do so will turn subsequent allocation into undefined behaviour.
 
 // Enable additional lints.
 #![warn(missing_docs)]
@@ -14,23 +17,37 @@
 #![no_std]
 
 use core::alloc::{GlobalAlloc, Layout};
-use core::ptr;
+use core::ptr::{self, NonNull};
 
 use uefi::prelude::*;
 use uefi::table::boot::{BootServices, MemoryType};
 
 /// Reference to the boot services table, used to call the pool memory allocation functions.
-static mut BOOT_SERVICES: Option<&BootServices> = None;
+///
+/// The inner pointer is only safe to dereference if UEFI boot services have not been
+/// exited by the host application yet.
+static mut BOOT_SERVICES: Option<NonNull<BootServices>> = None;
 
 /// Initializes the allocator.
-pub fn init(boot_services: &'static BootServices) {
-    unsafe {
-        BOOT_SERVICES = Some(boot_services);
-    }
+///
+/// You must make sure that exit_boot_services will be called before UEFI boot
+/// services are exited.
+pub unsafe fn init(boot_services: &BootServices) {
+    BOOT_SERVICES = NonNull::new(boot_services as *const _ as *mut _);
 }
 
-fn boot_services() -> &'static BootServices {
-    unsafe { BOOT_SERVICES.unwrap() }
+/// Access the boot services
+fn boot_services() -> NonNull<BootServices> {
+    unsafe { BOOT_SERVICES.expect("Boot services are unavailable or have been exited") }
+}
+
+/// Notify the allocator library that boot services are not safe to call anymore
+///
+/// You should call this function before exiting UEFI boot services.
+pub fn exit_boot_services() {
+    unsafe {
+        BOOT_SERVICES = None;
+    }
 }
 
 /// Allocator which uses the UEFI pool allocation functions.
@@ -50,6 +67,7 @@ unsafe impl GlobalAlloc for Allocator {
             ptr::null_mut()
         } else {
             boot_services()
+                .as_ref()
                 .allocate_pool(mem_ty, size)
                 .warning_as_error()
                 .unwrap_or(ptr::null_mut())
@@ -57,7 +75,7 @@ unsafe impl GlobalAlloc for Allocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        boot_services().free_pool(ptr).warning_as_error().unwrap();
+        boot_services().as_ref().free_pool(ptr).warning_as_error().unwrap();
     }
 }
 

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -3,7 +3,6 @@ use uefi::proto::Protocol;
 use uefi::table::boot::{BootServices, SearchType};
 use uefi::{Handle, Result};
 
-use core::ptr::NonNull;
 use crate::alloc::vec::Vec;
 
 /// Utility functions for the UEFI boot services.
@@ -12,7 +11,7 @@ pub trait BootServicesExt {
     fn find_handles<P: Protocol>(&self) -> Result<Vec<Handle>>;
 
     /// Returns a protocol implementation, if present on the system.
-    fn find_protocol<P: Protocol>(&self) -> Option<NonNull<P>>;
+    fn find_protocol<P: Protocol>(&self) -> Option<&mut P>;
 }
 
 impl BootServicesExt for BootServices {
@@ -43,7 +42,7 @@ impl BootServicesExt for BootServices {
             .map(|completion| completion.with_status(status2))
     }
 
-    fn find_protocol<P: Protocol>(&self) -> Option<NonNull<P>> {
+    fn find_protocol<P: Protocol>(&self) -> Option<&mut P> {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.

--- a/uefi-exts/src/boot.rs
+++ b/uefi-exts/src/boot.rs
@@ -1,3 +1,4 @@
+use core::cell::UnsafeCell;
 use uefi::prelude::*;
 use uefi::proto::Protocol;
 use uefi::table::boot::{BootServices, SearchType};
@@ -11,7 +12,9 @@ pub trait BootServicesExt {
     fn find_handles<P: Protocol>(&self) -> Result<Vec<Handle>>;
 
     /// Returns a protocol implementation, if present on the system.
-    fn find_protocol<P: Protocol>(&self) -> Option<&mut P>;
+    ///
+    /// The caveats of `BootServices::handle_protocol()` also apply here.
+    fn find_protocol<P: Protocol>(&self) -> Option<&UnsafeCell<P>>;
 }
 
 impl BootServicesExt for BootServices {
@@ -42,7 +45,7 @@ impl BootServicesExt for BootServices {
             .map(|completion| completion.with_status(status2))
     }
 
-    fn find_protocol<P: Protocol>(&self) -> Option<&mut P> {
+    fn find_protocol<P: Protocol>(&self) -> Option<&UnsafeCell<P>> {
         // Retrieve all handles implementing this.
         self.find_handles::<P>()
             // Convert to an option.

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -87,7 +87,7 @@ fn init_logger() {
 fn init_alloc() {
     let st = system_table();
 
-    uefi_alloc::init(st.boot);
+    uefi_alloc::init(st.boot_services());
 }
 
 #[lang = "eh_personality"]
@@ -110,7 +110,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     // Give the user some time to read the message
     if let Some(st) = unsafe { SYSTEM_TABLE } {
         // FIXME: Check if boot-time services have been exited too
-        st.boot.stall(10_000_000);
+        st.boot_services().stall(10_000_000);
     } else {
         let mut dummy = 0u64;
         // FIXME: May need different counter values in debug & release builds
@@ -133,7 +133,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     // If the system table is available, use UEFI's standard shutdown mechanism
     if let Some(st) = unsafe { SYSTEM_TABLE } {
         use uefi::table::runtime::ResetType;
-        st.runtime
+        st.runtime_services()
             .reset(ResetType::Shutdown, uefi::Status::ABORTED, None)
     }
 

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -62,25 +62,25 @@ pub fn system_table() -> NonNull<SystemTable> {
 /// This must be called as early as possible,
 /// before trying to use logging or memory allocation capabilities.
 pub fn init(st: &SystemTable) -> Result<()> {
-    // Avoid double initialization.
-    if unsafe { SYSTEM_TABLE.is_some() } {
-        return Status::SUCCESS.into();
-    }
-
-    // Setup the system table singleton
-    unsafe { SYSTEM_TABLE = NonNull::new(st as *const _ as *mut _) };
-
-    // Setup logging and memory allocation
-    let boot_services = st.boot_services();
     unsafe {
+        // Avoid double initialization.
+        if SYSTEM_TABLE.is_some() {
+            return Status::SUCCESS.into();
+        }
+
+        // Setup the system table singleton
+        SYSTEM_TABLE = NonNull::new(st as *const _ as *mut _);
+
+        // Setup logging and memory allocation
+        let boot_services = st.boot_services();
         init_logger(st);
         uefi_alloc::init(boot_services);
-    }
 
-    // Schedule these services to be shut down on exit from UEFI boot services
-    boot_services.create_event(EventType::SIGNAL_EXIT_BOOT_SERVICES,
-                               Tpl::NOTIFY,
-                               Some(exit_boot_services)).map_inner(|_| ())
+        // Schedule these tools to be disabled on exit from UEFI boot services
+        boot_services.create_event(EventType::SIGNAL_EXIT_BOOT_SERVICES,
+                                   Tpl::NOTIFY,
+                                   Some(exit_boot_services)).map_inner(|_| ())
+    }
 }
 
 /// Set up logging

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -34,7 +34,7 @@ use core::ptr::NonNull;
 
 use uefi::prelude::*;
 use uefi::table::boot::{EventType, Tpl};
-use uefi::table::BootSystemTable;
+use uefi::table::{Boot, SystemTable};
 use uefi::{Event, Result};
 
 /// Reference to the system table.
@@ -42,7 +42,7 @@ use uefi::{Event, Result};
 /// This table is only fully safe to use until UEFI boot services have been exited.
 /// After that, some fields and methods are unsafe to use, see the documentation of
 /// UEFI's ExitBootServices entry point for more details.
-static mut SYSTEM_TABLE: Option<BootSystemTable> = None;
+static mut SYSTEM_TABLE: Option<SystemTable<Boot>> = None;
 
 /// Global logger object
 static mut LOGGER: Option<uefi_logger::Logger> = None;
@@ -55,7 +55,7 @@ static mut LOGGER: Option<uefi_logger::Logger> = None;
 /// `init` must have been called first by the UEFI app.
 ///
 /// The returned pointer is only valid until boot services are exited.
-pub fn system_table() -> NonNull<BootSystemTable> {
+pub fn system_table() -> NonNull<SystemTable<Boot>> {
     unsafe {
         let table_ref = SYSTEM_TABLE
             .as_ref()
@@ -68,7 +68,7 @@ pub fn system_table() -> NonNull<BootSystemTable> {
 ///
 /// This must be called as early as possible,
 /// before trying to use logging or memory allocation capabilities.
-pub fn init(st: &BootSystemTable) -> Result<()> {
+pub fn init(st: &SystemTable<Boot>) -> Result<()> {
     unsafe {
         // Avoid double initialization.
         if SYSTEM_TABLE.is_some() {
@@ -98,7 +98,7 @@ pub fn init(st: &BootSystemTable) -> Result<()> {
 ///
 /// This is unsafe because you must arrange for the logger to be reset with
 /// disable() on exit from UEFI boot services.
-unsafe fn init_logger(st: &BootSystemTable) {
+unsafe fn init_logger(st: &SystemTable<Boot>) {
     let stdout = st.stdout();
 
     // Construct the logger.

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -30,18 +30,26 @@ extern crate uefi_alloc;
 #[macro_use]
 extern crate log;
 
+use core::ptr::NonNull;
 use uefi::table::SystemTable;
 
 /// Reference to the system table.
-static mut SYSTEM_TABLE: Option<&'static SystemTable> = None;
+///
+/// This table is only fully safe to use until UEFI boot services have been exited.
+/// After that, some fields and methods are unsafe to use, see the documentation of
+/// UEFI's ExitBootServices entry point for more details.
+static mut SYSTEM_TABLE: Option<NonNull<SystemTable>> = None;
 
-/// Obtains a reference to the system table.
+/// Global logger object
+static mut LOGGER: Option<uefi_logger::Logger> = None;
+
+/// Obtains a pointer to the system table.
 ///
 /// This is meant to be used by higher-level libraries,
 /// which want a convenient way to access the system table singleton.
 ///
 /// `init` must have been called first by the UEFI app.
-pub fn system_table() -> &'static SystemTable {
+pub fn system_table() -> NonNull<SystemTable> {
     unsafe { SYSTEM_TABLE.expect("The uefi-services library has not yet been initialized") }
 }
 
@@ -49,31 +57,27 @@ pub fn system_table() -> &'static SystemTable {
 ///
 /// This must be called as early as possible,
 /// before trying to use logging or memory allocation capabilities.
-pub fn init(st: &'static SystemTable) {
-    unsafe {
-        // Avoid double initialization.
-        if SYSTEM_TABLE.is_some() {
-            return;
-        }
-
-        SYSTEM_TABLE = Some(st);
+///
+/// You must make sure that exit_boot_services will be called before UEFI boot
+/// services are exited.
+pub unsafe fn init(st: &SystemTable) {
+    // Avoid double initialization.
+    if SYSTEM_TABLE.is_some() {
+        return;
     }
 
-    init_logger();
-    init_alloc();
+    SYSTEM_TABLE = NonNull::new(st as *const _ as *mut _);
+
+    init_logger(st);
+    init_alloc(st);
 }
 
-fn init_logger() {
-    let st = system_table();
-
-    static mut LOGGER: Option<uefi_logger::Logger> = None;
-
+unsafe fn init_logger(st: &SystemTable) {
     let stdout = st.stdout();
 
     // Construct the logger.
-    let logger = unsafe {
+    let logger = {
         LOGGER = Some(uefi_logger::Logger::new(stdout));
-
         LOGGER.as_ref().unwrap()
     };
 
@@ -84,10 +88,19 @@ fn init_logger() {
     log::set_max_level(log::LevelFilter::Info);
 }
 
-fn init_alloc() {
-    let st = system_table();
-
+unsafe fn init_alloc(st: &SystemTable) {
     uefi_alloc::init(st.boot_services());
+}
+
+/// Notify the utility library that boot services are not safe to call anymore
+pub fn exit_boot_services() {
+    unsafe {
+        SYSTEM_TABLE = None;
+        if let Some(ref mut logger) = LOGGER {
+            logger.disable();
+        }
+    }
+    uefi_alloc::exit_boot_services();
 }
 
 #[lang = "eh_personality"]
@@ -109,8 +122,11 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     // Give the user some time to read the message
     if let Some(st) = unsafe { SYSTEM_TABLE } {
-        // FIXME: Check if boot-time services have been exited too
-        st.boot_services().stall(10_000_000);
+        // This is safe if the user makes sure to call exit_boot_services before
+        // exiting UEFI's boot services, as that will reset SYSTEM_TABLE.
+        unsafe {
+            st.as_ref().boot_services().stall(10_000_000);
+        }
     } else {
         let mut dummy = 0u64;
         // FIXME: May need different counter values in debug & release builds
@@ -133,8 +149,11 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     // If the system table is available, use UEFI's standard shutdown mechanism
     if let Some(st) = unsafe { SYSTEM_TABLE } {
         use uefi::table::runtime::ResetType;
-        st.runtime_services()
-            .reset(ResetType::Shutdown, uefi::Status::ABORTED, None)
+        unsafe {
+            st.as_ref()
+                .runtime_services()
+                .reset(ResetType::Shutdown, uefi::Status::ABORTED, None)
+        }
     }
 
     // If we don't have any shutdown mechanism handy, the best we can do is loop

--- a/uefi-services/src/lib.rs
+++ b/uefi-services/src/lib.rs
@@ -112,6 +112,12 @@ unsafe fn init_logger(st: &BootSystemTable) {
 
 /// Notify the utility library that boot services are not safe to call anymore
 fn exit_boot_services(_e: Event) {
+    // DEBUG: The UEFI spec does not guarantee that this printout will work, as
+    //        the services used by logging might already have been shut down.
+    //        But it works on current OVMF, and can be used as a handy way to
+    //        check that the callback does get called.
+    //
+    // info!("Shutting down the UEFI utility library");
     unsafe {
         SYSTEM_TABLE = None;
         if let Some(ref mut logger) = LOGGER {

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -64,10 +64,9 @@ fn check_revision(rev: uefi::table::Revision) {
 fn check_screenshot(bt: &BootServices, name: &str) {
     if cfg!(feature = "qemu") {
         // Access the serial port (in a QEMU environment, it should always be there)
-        let mut serial = bt
+        let serial = bt
             .find_protocol::<Serial>()
             .expect("Could not find serial port");
-        let serial = unsafe { serial.as_mut() };
 
         // Set a large timeout to avoid problems with Travis
         let mut io_mode = *serial.io_mode();

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -20,7 +20,9 @@ mod proto;
 #[no_mangle]
 pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable) -> Status {
     // Initialize logging.
-    unsafe { uefi_services::init(st); }
+    unsafe {
+        uefi_services::init(st);
+    }
 
     // Reset the console before running all the other tests.
     st.stdout()

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -67,6 +67,7 @@ fn check_screenshot(bt: &BootServices, name: &str) {
         let serial = bt
             .find_protocol::<Serial>()
             .expect("Could not find serial port");
+        let serial = unsafe { &mut *serial.get() };
 
         // Set a large timeout to avoid problems with Travis
         let mut io_mode = *serial.io_mode();

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -31,7 +31,7 @@ pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable
     check_revision(st.uefi_revision());
 
     // Test all the boot services.
-    let bt = st.boot;
+    let bt = st.boot_services();
     boot::test(bt);
 
     // TODO: test the runtime services.
@@ -107,11 +107,11 @@ fn shutdown(st: &SystemTable) -> ! {
     // Inform the user, and give him time to read on real hardware
     if cfg!(not(feature = "qemu")) {
         info!("Testing complete, shutting down in 3 seconds...");
-        st.boot.stall(3_000_000);
+        st.boot_services().stall(3_000_000);
     } else {
         info!("Testing complete, shutting down...");
     }
 
-    let rt = st.runtime;
+    let rt = st.runtime_services();
     rt.reset(ResetType::Shutdown, Status::SUCCESS, None);
 }

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -20,7 +20,7 @@ mod proto;
 #[no_mangle]
 pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable) -> Status {
     // Initialize logging.
-    uefi_services::init(st);
+    unsafe { uefi_services::init(st); }
 
     // Reset the console before running all the other tests.
     st.stdout()

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -19,10 +19,8 @@ mod proto;
 
 #[no_mangle]
 pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable) -> Status {
-    // Initialize logging.
-    unsafe {
-        uefi_services::init(st);
-    }
+    // Initialize utilities (logging, memory allocation...)
+    uefi_services::init(st).expect_success("Failed to initialize utilities");
 
     // Reset the console before running all the other tests.
     st.stdout()

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -18,9 +18,9 @@ mod boot;
 mod proto;
 
 #[no_mangle]
-pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable) -> Status {
+pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: BootSystemTable) -> Status {
     // Initialize utilities (logging, memory allocation...)
-    uefi_services::init(st).expect_success("Failed to initialize utilities");
+    uefi_services::init(&st).expect_success("Failed to initialize utilities");
 
     // Reset the console before running all the other tests.
     st.stdout()
@@ -38,9 +38,9 @@ pub extern "win64" fn uefi_start(_handle: uefi::Handle, st: &'static SystemTable
     // We would have to call `exit_boot_services` first to ensure things work properly.
 
     // Test all the supported protocols.
-    proto::test(st);
+    proto::test(&st);
 
-    shutdown(st);
+    shutdown(&st);
 }
 
 fn check_revision(rev: uefi::table::Revision) {
@@ -99,7 +99,7 @@ fn check_screenshot(bt: &BootServices, name: &str) {
     }
 }
 
-fn shutdown(st: &SystemTable) -> ! {
+fn shutdown(st: &BootSystemTable) -> ! {
     use uefi::table::runtime::ResetType;
 
     // Get our text output back.

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -117,10 +117,11 @@ fn shutdown(image: uefi::Handle, st: SystemTable<Boot>) -> ! {
     // Exit boot services as a proof that it works :)
     use crate::alloc::vec::Vec;
     let max_mmap_size = st.boot_services().memory_map_size() + 1024;
-    let mut mmap_storage = Vec::with_capacity(max_mmap_size);
-    unsafe {
+    let mut mmap_storage = unsafe {
+        let mut mmap_storage = Vec::with_capacity(max_mmap_size);
         mmap_storage.set_len(max_mmap_size);
-    }
+        mmap_storage.into_boxed_slice()
+    };
     let (st, _iter) = st
         .exit_boot_services(image, &mut mmap_storage[..])
         .expect_success("Failed to exit boot services");

--- a/uefi-test-runner/src/main.rs
+++ b/uefi-test-runner/src/main.rs
@@ -18,7 +18,7 @@ mod boot;
 mod proto;
 
 #[no_mangle]
-pub extern "win64" fn uefi_start(image: uefi::Handle, st: BootSystemTable) -> Status {
+pub extern "win64" fn uefi_start(image: uefi::Handle, st: SystemTable<Boot>) -> Status {
     // Initialize utilities (logging, memory allocation...)
     uefi_services::init(&st).expect_success("Failed to initialize utilities");
 
@@ -100,7 +100,7 @@ fn check_screenshot(bt: &BootServices, name: &str) {
     }
 }
 
-fn shutdown(image: uefi::Handle, st: BootSystemTable) -> ! {
+fn shutdown(image: uefi::Handle, st: SystemTable<Boot>) -> ! {
     use uefi::table::runtime::ResetType;
 
     // Get our text output back.

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -5,9 +5,7 @@ use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running graphics output protocol test");
-    if let Some(mut gop_proto) = bt.find_protocol::<GraphicsOutput>() {
-        let gop = unsafe { gop_proto.as_mut() };
-
+    if let Some(gop) = bt.find_protocol::<GraphicsOutput>() {
         set_graphics_mode(gop);
         fill_color(gop);
         draw_fb(gop);

--- a/uefi-test-runner/src/proto/console/gop.rs
+++ b/uefi-test-runner/src/proto/console/gop.rs
@@ -6,6 +6,8 @@ use uefi_exts::BootServicesExt;
 pub fn test(bt: &BootServices) {
     info!("Running graphics output protocol test");
     if let Some(gop) = bt.find_protocol::<GraphicsOutput>() {
+        let gop = unsafe { &mut *gop.get() };
+
         set_graphics_mode(gop);
         fill_color(gop);
         draw_fb(gop);

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,6 +1,6 @@
-use uefi::table::BootSystemTable;
+use uefi::prelude::*;
 
-pub fn test(st: &BootSystemTable) {
+pub fn test(st: &SystemTable<Boot>) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -5,7 +5,7 @@ pub fn test(st: &SystemTable) {
 
     stdout::test(st.stdout());
 
-    let bt = st.boot;
+    let bt = st.boot_services();
     serial::test(bt);
     gop::test(bt);
     pointer::test(bt);

--- a/uefi-test-runner/src/proto/console/mod.rs
+++ b/uefi-test-runner/src/proto/console/mod.rs
@@ -1,6 +1,6 @@
-use uefi::table::SystemTable;
+use uefi::table::BootSystemTable;
 
-pub fn test(st: &SystemTable) {
+pub fn test(st: &BootSystemTable) {
     info!("Testing console protocols");
 
     stdout::test(st.stdout());

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -7,6 +7,8 @@ use uefi_exts::BootServicesExt;
 pub fn test(bt: &BootServices) {
     info!("Running pointer protocol test");
     if let Some(pointer) = bt.find_protocol::<Pointer>() {
+        let pointer = unsafe { &mut *pointer.get() };
+
         pointer
             .reset(false)
             .expect_success("Failed to reset pointer device");

--- a/uefi-test-runner/src/proto/console/pointer.rs
+++ b/uefi-test-runner/src/proto/console/pointer.rs
@@ -6,9 +6,7 @@ use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running pointer protocol test");
-    if let Some(mut pointer) = bt.find_protocol::<Pointer>() {
-        let pointer = unsafe { pointer.as_mut() };
-
+    if let Some(pointer) = bt.find_protocol::<Pointer>() {
         pointer
             .reset(false)
             .expect_success("Failed to reset pointer device");

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -5,9 +5,7 @@ use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running serial protocol test");
-    if let Some(mut serial) = bt.find_protocol::<Serial>() {
-        let serial = unsafe { serial.as_mut() };
-
+    if let Some(serial) = bt.find_protocol::<Serial>() {
         let old_ctrl_bits = serial
             .get_control_bits()
             .expect_success("Failed to get device control bits");

--- a/uefi-test-runner/src/proto/console/serial.rs
+++ b/uefi-test-runner/src/proto/console/serial.rs
@@ -6,6 +6,8 @@ use uefi_exts::BootServicesExt;
 pub fn test(bt: &BootServices) {
     info!("Running serial protocol test");
     if let Some(serial) = bt.find_protocol::<Serial>() {
+        let serial = unsafe { &mut *serial.get() };
+
         let old_ctrl_bits = serial
             .get_control_bits()
             .expect_success("Failed to get device control bits");

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -5,9 +5,7 @@ use uefi_exts::BootServicesExt;
 
 pub fn test(bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
-    if let Some(mut debug_support_proto) = bt.find_protocol::<DebugSupport>() {
-        let debug_support = unsafe { debug_support_proto.as_mut() };
-
+    if let Some(debug_support) = bt.find_protocol::<DebugSupport>() {
         info!("- Architecture: {:?}", debug_support.arch());
     } else {
         warn!("Debug protocol is not supported");

--- a/uefi-test-runner/src/proto/debug.rs
+++ b/uefi-test-runner/src/proto/debug.rs
@@ -6,6 +6,8 @@ use uefi_exts::BootServicesExt;
 pub fn test(bt: &BootServices) {
     info!("Running UEFI debug connection protocol test");
     if let Some(debug_support) = bt.find_protocol::<DebugSupport>() {
+        let debug_support = unsafe { &mut *debug_support.get() };
+
         info!("- Architecture: {:?}", debug_support.arch());
     } else {
         warn!("Debug protocol is not supported");

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -3,7 +3,7 @@ use uefi_exts::BootServicesExt;
 
 use uefi::proto;
 
-pub fn test(st: &BootSystemTable) {
+pub fn test(st: &SystemTable<Boot>) {
     info!("Testing various protocols");
 
     let bt = st.boot_services();

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -6,7 +6,7 @@ use uefi::proto;
 pub fn test(st: &SystemTable) {
     info!("Testing various protocols");
 
-    let bt = st.boot;
+    let bt = st.boot_services();
 
     find_protocol(bt);
 

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -3,7 +3,7 @@ use uefi_exts::BootServicesExt;
 
 use uefi::proto;
 
-pub fn test(st: &SystemTable) {
+pub fn test(st: &BootSystemTable) {
     info!("Testing various protocols");
 
     let bt = st.boot_services();

--- a/uefi-test-runner/src/proto/mod.rs
+++ b/uefi-test-runner/src/proto/mod.rs
@@ -15,7 +15,7 @@ pub fn test(st: &SystemTable) {
 }
 
 fn find_protocol(bt: &BootServices) {
-    type SearchedProtocol = proto::console::text::Output;
+    type SearchedProtocol<'a> = proto::console::text::Output<'a>;
 
     let handles = bt
         .find_handles::<SearchedProtocol>()


### PR DESCRIPTION
This PR gives uefi-rs a solid type-safety cleanup (e.g. no more "usize" as a substitute for pointers, and using 'static when that's a lie is avoided). Most importantly, however, it also fixes #3 by providing a safe method to exit UEFI boot services, ensuring that the borrow checker will warn you if you try to use boot services after the fact.

Achieving this result required a significant redesign of how protocols work. Previously, protocols were assumed to live forever, whereas now they are treated as a reference to UEFI boot services. Some lifetime inconvenience results, and impl Trait may not be used quite as frequently as before, but overall the patch remains remarkably simple considering what it does.

The type-safety cleanup fixes #23 .